### PR TITLE
Support preAuth

### DIFF
--- a/examples/directToLLMTransports/package-lock.json
+++ b/examples/directToLLMTransports/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@pipecat-ai/client-js": "^0.3.1",
+        "@pipecat-ai/client-js": "^0.3.4",
         "@pipecat-ai/gemini-live-websocket-transport": "file:../../transports/gemini-live-websocket-transport",
         "@pipecat-ai/openai-realtime-webrtc-transport": "file:../../transports/openai-realtime-webrtc-transport",
         "@pipecat-ai/realtime-websocket-transport": "file:../../transports/realtime-websocket-transport",
@@ -32,62 +32,55 @@
     },
     "../../transports/gemini-live-websocket-transport": {
       "name": "@pipecat-ai/gemini-live-websocket-transport",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BSD-2-Clause",
       "devDependencies": {
-        "@pipecat-ai/client-js": "~0.3.0",
-        "@pipecat-ai/realtime-websocket-transport": "*",
+        "@pipecat-ai/client-js": "~0.3.4",
+        "@pipecat-ai/realtime-websocket-transport": "~0.3.4",
         "@types/node": "^22.9.0",
-        "@typescript-eslint/eslint-plugin": "^7.16.0",
-        "@typescript-eslint/parser": "^7.16.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~0.3.0",
-        "@pipecat-ai/realtime-websocket-transport": "~0.3.3"
+        "@pipecat-ai/client-js": "~0.3.4",
+        "@pipecat-ai/realtime-websocket-transport": "~0.3.4"
       }
     },
     "../../transports/openai-realtime-webrtc-transport": {
       "name": "@pipecat-ai/openai-realtime-webrtc-transport",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.73.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "~0.3.0",
+        "@pipecat-ai/client-js": "~0.3.4",
         "@types/node": "^22.9.0",
-        "@typescript-eslint/eslint-plugin": "^7.16.0",
-        "@typescript-eslint/parser": "^7.16.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~0.3.0",
-        "@pipecat-ai/llm-direct-transport": "~0.3.3"
+        "@pipecat-ai/client-js": "~0.3.4"
       }
     },
     "../../transports/realtime-websocket-transport": {
       "name": "@pipecat-ai/realtime-websocket-transport",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.73.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "~0.3.0",
+        "@pipecat-ai/client-js": "~0.3.4",
         "@types/node": "^22.9.0",
-        "@typescript-eslint/eslint-plugin": "^7.16.0",
-        "@typescript-eslint/parser": "^7.16.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~0.3.0"
+        "@pipecat-ai/client-js": "~0.3.4"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -675,9 +668,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-0.3.1.tgz",
-      "integrity": "sha512-qUcZKPXP4rYzEZcNDVtCDj6RhieTYutFgF0hnC/v6Jq1T2KY9XrKrrioXY5wO1MlWRo2CzUvLDFfKw/KOWS9yA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-0.3.4.tgz",
+      "integrity": "sha512-xX4/65fT82ZGVxAZWojflY9EzI50H0dl9tBw1s4VUfF+zU4yCpYw2w/sVLU618xcbnZKlCesmxrtmCABdWEGdA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",

--- a/examples/directToLLMTransports/package.json
+++ b/examples/directToLLMTransports/package.json
@@ -12,13 +12,13 @@
   "license": "BSD-2-Clause",
   "description": "",
   "dependencies": {
-    "@pipecat-ai/realtime-websocket-transport": "file:../../transports/realtime-websocket-transport",
+    "@pipecat-ai/client-js": "^0.3.4",
     "@pipecat-ai/gemini-live-websocket-transport": "file:../../transports/gemini-live-websocket-transport",
     "@pipecat-ai/openai-realtime-webrtc-transport": "file:../../transports/openai-realtime-webrtc-transport",
+    "@pipecat-ai/realtime-websocket-transport": "file:../../transports/realtime-websocket-transport",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
-    "morgan": "^1.10.0",
-    "@pipecat-ai/client-js": "^0.3.1"
+    "morgan": "^1.10.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,9 +1684,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-0.3.2.tgz",
-      "integrity": "sha512-psunOVrJjPka2SWlq53vxVWCA0Vt8pSXsXtn8pOLC0YTKFsUx+b7Z6quYUJcDZjCe1aAg9cKETek3Xal3Co8Tg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-0.3.4.tgz",
+      "integrity": "sha512-xX4/65fT82ZGVxAZWojflY9EzI50H0dl9tBw1s4VUfF+zU4yCpYw2w/sVLU618xcbnZKlCesmxrtmCABdWEGdA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4104,13 +4104,13 @@
         "@daily-co/daily-js": "^0.73.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "~0.3.2",
+        "@pipecat-ai/client-js": "~0.3.4",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~0.3.2"
+        "@pipecat-ai/client-js": "~0.3.4"
       }
     },
     "transports/gemini-live-websocket-transport": {
@@ -4118,7 +4118,7 @@
       "version": "0.3.4",
       "license": "BSD-2-Clause",
       "devDependencies": {
-        "@pipecat-ai/client-js": "~0.3.2",
+        "@pipecat-ai/client-js": "~0.3.4",
         "@pipecat-ai/realtime-websocket-transport": "~0.3.4",
         "@types/node": "^22.9.0",
         "eslint": "9.11.1",
@@ -4126,7 +4126,7 @@
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~0.3.2",
+        "@pipecat-ai/client-js": "~0.3.4",
         "@pipecat-ai/realtime-websocket-transport": "~0.3.4"
       }
     },
@@ -4138,14 +4138,14 @@
         "@daily-co/daily-js": "^0.73.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "~0.3.2",
+        "@pipecat-ai/client-js": "~0.3.4",
         "@types/node": "^22.9.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~0.3.2"
+        "@pipecat-ai/client-js": "~0.3.4"
       }
     },
     "transports/realtime-websocket-transport": {
@@ -4156,14 +4156,14 @@
         "@daily-co/daily-js": "^0.73.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "~0.3.2",
+        "@pipecat-ai/client-js": "~0.3.4",
         "@types/node": "^22.9.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~0.3.2"
+        "@pipecat-ai/client-js": "~0.3.4"
       }
     }
   }

--- a/transports/daily/package.json
+++ b/transports/daily/package.json
@@ -21,13 +21,13 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "~0.3.2",
+    "@pipecat-ai/client-js": "~0.3.4",
     "eslint": "9.11.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~0.3.2"
+    "@pipecat-ai/client-js": "~0.3.4"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.73.0"

--- a/transports/gemini-live-websocket-transport/package.json
+++ b/transports/gemini-live-websocket-transport/package.json
@@ -21,15 +21,15 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "~0.3.2",
+    "@pipecat-ai/client-js": "~0.3.4",
     "@pipecat-ai/realtime-websocket-transport": "~0.3.4",
+    "@types/node": "^22.9.0",
     "eslint": "9.11.1",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-simple-import-sort": "^12.1.1",
-    "@types/node": "^22.9.0"
+    "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~0.3.2",
+    "@pipecat-ai/client-js": "~0.3.4",
     "@pipecat-ai/realtime-websocket-transport": "~0.3.4"
   },
   "description": "Pipecat Gemini Multimodal Live Transport Package",

--- a/transports/openai-realtime-webrtc-transport/package.json
+++ b/transports/openai-realtime-webrtc-transport/package.json
@@ -21,14 +21,14 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "~0.3.2",
+    "@pipecat-ai/client-js": "~0.3.4",
+    "@types/node": "^22.9.0",
     "eslint": "9.11.1",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-simple-import-sort": "^12.1.1",
-    "@types/node": "^22.9.0"
+    "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~0.3.2"
+    "@pipecat-ai/client-js": "~0.3.4"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.73.0"

--- a/transports/openai-realtime-webrtc-transport/src/OpenAIRealTimeWebRTCTransport.ts
+++ b/transports/openai-realtime-webrtc-transport/src/OpenAIRealTimeWebRTCTransport.ts
@@ -156,6 +156,8 @@ export class OpenAIRealTimeWebRTCTransport extends Transport {
     await this._disconnectLLM();
     this.state = "disconnected";
     this._callbacks.onDisconnected?.();
+
+    this.initialize(this._options, this._onMessage);
   }
 
   get state(): TransportState {

--- a/transports/realtime-websocket-transport/package.json
+++ b/transports/realtime-websocket-transport/package.json
@@ -21,14 +21,14 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "~0.3.2",
+    "@pipecat-ai/client-js": "~0.3.4",
+    "@types/node": "^22.9.0",
     "eslint": "9.11.1",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-simple-import-sort": "^12.1.1",
-    "@types/node": "^22.9.0"
+    "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~0.3.2"
+    "@pipecat-ai/client-js": "~0.3.4"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.73.0"


### PR DESCRIPTION
From the first commit... This PR

Updates the daily instance in the daily transport to:
1. Make it available immediately upon Transport construction
2. Fix use of daily factory options to work better alongside rtvi options
3. Add support for calling preAuth()
4. Change how disconnect works such that the transport no longer re-creates
   a new daily instance but re-uses the one it has so there is 1:1
   transport -> daily instance.
   
And updates the OpenAIRealTimeWebRTCTransport to work with the changes laid out in this [client-js PR](https://github.com/pipecat-ai/pipecat-client-web/pull/98)