### PR TITLE
call initDevices from initialize

### DIFF
--- a/transports/openai-realtime-webrtc-transport/src/OpenAIRealTimeWebRTCTransport.ts
+++ b/transports/openai-realtime-webrtc-transport/src/OpenAIRealTimeWebRTCTransport.ts
@@ -143,6 +143,8 @@ export class OpenAIRealTimeWebRTCTransport extends Transport {
       this._attachDeviceListeners();
     }
 
+    this.initDevices();
+
     this._attachLLMListeners();
 
     this.state = "initialized";


### PR DESCRIPTION
This makes sure that media devices are initialized correctly.