### PR TITLE
refactor(webrtc): Improve ICE server configuration in SmallWebRTCConnection

### DIFF
--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -72,7 +72,7 @@ export class SmallWebRTCTransport extends Transport {
   private isReconnecting = false;
   private keepAliveInterval: number | null = null;
 
-  private _iceServers: string[] = ["stun:stun.l.google.com:19302"];
+  private _iceServers: RTCIceServer[] = [];
 
   constructor() {
     super();
@@ -209,7 +209,7 @@ export class SmallWebRTCTransport extends Transport {
 
   private createPeerConnection(): RTCPeerConnection {
     const config: RTCConfiguration = {
-      iceServers: [{ urls: this._iceServers }],
+      iceServers: this._iceServers,
     };
 
     let pc = new RTCPeerConnection(config);

--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -20,6 +20,7 @@ class TrackStatusMessage {
 }
 
 export interface SmallWebRTCTransportConstructorOptions {
+  iceServers?: RTCIceServer[];
   waitForICEGathering?: boolean;
 }
 
@@ -80,9 +81,11 @@ export class SmallWebRTCTransport extends Transport {
   private readonly _waitForICEGathering: boolean
 
   constructor({
+    iceServers = [],
     waitForICEGathering = false
   }: SmallWebRTCTransportConstructorOptions = {}) {
     super();
+    this._iceServers = iceServers;
     this._waitForICEGathering = waitForICEGathering;
     this.mediaManager = new DailyMediaManager(
       false,


### PR DESCRIPTION
This PR refactors the `SmallWebRTCConnection` constructor, introduces a new constructor option, `waitForICEGathering` (boolean, defaults to `false`) to improve how ICE servers are handled.

**Changes:**

* Added `waitForICEGathering` property to newly added `SmallWebRTCTransportConstructorOptions` interface and update the stored private member variable `_waitForICEGathering` within the `SmallWebRTCTransport` class via the constructor.
* Updated the `negotiate` method to use the stored instance configuration to control the waiting logic.
* The `_iceServers` private member variable in `SmallWebRTCTransport` class now accepts `RTCIceServer[]` instead of just the `string[]` of urls.
* Update the setter of `iceServers` for the new type change.

**Motivation:**

* This change allows users to pass pre-configured `RTCIceServer` objects directly, which is particularly useful for more complex setups involving TURN servers that require credentials.
* This allows users to configure whether the transport should explicitly wait for the `iceGatheringState` to become `complete` during the negotiation phase (`negotiate` method) before sending the SDP offer. It would provides more control over the WebRTC connection setup, particularly useful in scenarios where ensuring all ICE candidates are gathered is necessary before proceeding, or conversely, when faster setup is preferred by not waiting.
*  It improves type safety and makes the expected input clearer.
