### PR TITLE
small-webrtc-transport: set state "ready"

### DIFF
--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -190,6 +190,7 @@ export class SmallWebRTCTransport extends Transport {
   }
 
   sendReadyMessage() {
+    this.state = "ready";
     // Sending message that the client is ready, just for testing
     //this.dc?.send(JSON.stringify({id: 'clientReady', label: 'rtvi-ai', type:'client-ready'}))
     this.sendMessage(RTVIMessage.clientReady());


### PR DESCRIPTION
This makes RTVI actions work with small webrtc transport.

Unless [transport state is "ready"](https://github.com/pipecat-ai/pipecat-client-web/blob/ab3fc9801f4d0be16b68be62e1aca6abdf432729/client-js/src/decorators.ts#L18), RTVI actions [will not work](https://github.com/pipecat-ai/pipecat-client-web/blob/ab3fc9801f4d0be16b68be62e1aca6abdf432729/client-js/src/decorators.ts#L22).

