### PR TITLE
Update connection url naming

### DIFF
--- a/examples/directToLLMTransports/package-lock.json
+++ b/examples/directToLLMTransports/package-lock.json
@@ -31,7 +31,7 @@
     },
     "../../transports/gemini-live-websocket-transport": {
       "name": "@pipecat-ai/gemini-live-websocket-transport",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.79.0"
@@ -49,7 +49,7 @@
     },
     "../../transports/openai-realtime-webrtc-transport": {
       "name": "@pipecat-ai/openai-realtime-webrtc-transport",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.77.0",

--- a/examples/directToLLMTransports/package-lock.json
+++ b/examples/directToLLMTransports/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@pipecat-ai/client-js": "^1.1.0",
+        "@pipecat-ai/client-js": "^1.2.0",
         "@pipecat-ai/gemini-live-websocket-transport": "file:../../transports/gemini-live-websocket-transport",
         "@pipecat-ai/openai-realtime-webrtc-transport": "file:../../transports/openai-realtime-webrtc-transport",
         "dotenv": "^16.4.5",
@@ -37,14 +37,14 @@
         "@daily-co/daily-js": "^0.79.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.1.0",
+        "@pipecat-ai/client-js": "^1.2.0",
         "@types/node": "^22.9.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.1.0"
+        "@pipecat-ai/client-js": "~1.2.0"
       }
     },
     "../../transports/openai-realtime-webrtc-transport": {
@@ -56,14 +56,14 @@
         "dequal": "^2.0.3"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.1.0",
+        "@pipecat-ai/client-js": "^1.2.0",
         "@types/node": "^22.9.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.1.0"
+        "@pipecat-ai/client-js": "~1.2.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -706,9 +706,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.1.0.tgz",
-      "integrity": "sha512-w0oWpUZVsijfQaj5qO8sDhxoJdcSoOQWmM0HKQeWleaIQIEx1A4zC6ipEPVinpYVpfg+5BDFqYSWpQXBwNUGiA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.2.0.tgz",
+      "integrity": "sha512-T1RQE7bBD35vq6RHA8Oc1NyBOCOR7FqvpTGH1+e24n4TbXspz9jK4kuj1CoBK02BTKZ+UHJlkHnG9DRLtxpf+A==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",

--- a/examples/directToLLMTransports/package.json
+++ b/examples/directToLLMTransports/package.json
@@ -12,7 +12,7 @@
   "license": "BSD-2-Clause",
   "description": "",
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.1.0",
+    "@pipecat-ai/client-js": "^1.2.0",
     "@pipecat-ai/gemini-live-websocket-transport": "file:../../transports/gemini-live-websocket-transport",
     "@pipecat-ai/openai-realtime-webrtc-transport": "file:../../transports/openai-realtime-webrtc-transport",
     "dotenv": "^16.4.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       },
       "peerDependencies": {
         "@daily-co/daily-js": "^0.77.0",
-        "@pipecat-ai/client-js": "^1.1.0"
+        "@pipecat-ai/client-js": "^1.2.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.1.0.tgz",
-      "integrity": "sha512-w0oWpUZVsijfQaj5qO8sDhxoJdcSoOQWmM0HKQeWleaIQIEx1A4zC6ipEPVinpYVpfg+5BDFqYSWpQXBwNUGiA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.2.0.tgz",
+      "integrity": "sha512-T1RQE7bBD35vq6RHA8Oc1NyBOCOR7FqvpTGH1+e24n4TbXspz9jK4kuj1CoBK02BTKZ+UHJlkHnG9DRLtxpf+A==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",
@@ -4699,13 +4699,13 @@
         "@daily-co/daily-js": "^0.77.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.1.0",
+        "@pipecat-ai/client-js": "^1.2.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.1.0"
+        "@pipecat-ai/client-js": "~1.2.0"
       }
     },
     "transports/gemini-live-websocket-transport": {
@@ -4716,14 +4716,14 @@
         "@daily-co/daily-js": "^0.79.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.1.0",
+        "@pipecat-ai/client-js": "^1.2.0",
         "@types/node": "^22.9.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.1.0"
+        "@pipecat-ai/client-js": "~1.2.0"
       }
     },
     "transports/gemini-live-websocket-transport/node_modules/@daily-co/daily-js": {
@@ -4751,14 +4751,14 @@
         "dequal": "^2.0.3"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.1.0",
+        "@pipecat-ai/client-js": "^1.2.0",
         "@types/node": "^22.9.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.1.0"
+        "@pipecat-ai/client-js": "~1.2.0"
       }
     },
     "transports/small-webrtc-transport": {
@@ -4770,14 +4770,14 @@
         "dequal": "^2.0.3"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.1.0",
+        "@pipecat-ai/client-js": "^1.2.0",
         "@types/node": "^22.9.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.1.0"
+        "@pipecat-ai/client-js": "~1.2.0"
       }
     },
     "transports/websocket-transport": {
@@ -4791,14 +4791,14 @@
         "x-law": "^0.3.1"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.1.0",
+        "@pipecat-ai/client-js": "^1.2.0",
         "@types/node": "^22.9.0",
         "eslint": "9.11.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.1.0"
+        "@pipecat-ai/client-js": "~1.2.0"
       }
     },
     "transports/websocket-transport/node_modules/@daily-co/daily-js": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "peerDependencies": {
     "@daily-co/daily-js": "^0.77.0",
-    "@pipecat-ai/client-js": "^1.1.0"
+    "@pipecat-ai/client-js": "^1.2.0"
   }
 }

--- a/set-client-js.sh
+++ b/set-client-js.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Script to set client-js package across project directories
+# Usage: ./set-client-js.sh <package-spec>
+# Examples:
+#   ./set-client-js.sh /path/to/local/client-js     # Install from local path
+#   ./set-client-js.sh @pipecat-ai/client-js        # Install from npm
+#   ./set-client-js.sh @pipecat-ai/client-js@1.2.3  # Install specific version
+
+set -e  # Exit on any error
+
+# Check if package spec argument is provided
+if [ $# -eq 0 ]; then
+    echo "Error: Please provide a package specification"
+    echo "Usage: $0 <package-spec>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 /path/to/local/client-js        # Install from local path"
+    echo "  $0 1.2.3                           # Install specific version"
+    exit 1
+fi
+
+PACKAGE_SPEC="$1"
+
+# Determine if this is a local path or npm package
+if [ -d "$PACKAGE_SPEC" ]; then
+    # It's a local directory
+    PACKAGE_SPEC=$(realpath "$PACKAGE_SPEC")
+    INSTALL_SPEC="@pipecat-ai/client-js@file:$PACKAGE_SPEC"
+    LOCAL_INSTALL=true
+    echo "Installing local client-js from: $PACKAGE_SPEC"
+else
+    # It's an npm package spec
+    INSTALL_SPEC="$PACKAGE_SPEC"
+    LOCAL_INSTALL=false
+    echo "Installing client-js package: $PACKAGE_SPEC"
+fi
+
+# Function to install in a directory
+install_in_dir() {
+    local dir="$1"
+    if [ -d "$dir" ] && [ -f "$dir/package.json" ]; then
+        echo "Installing in: $dir"
+        cd "$dir"
+        if [ "$LOCAL_INSTALL" = true ]; then
+            # Use local path installation
+            npm install "$INSTALL_SPEC"
+        else
+            if [[ "$dir" == *"transports"* ]]; then
+                # Install as peer and dev dependency in transport directories
+                npm install --save-peer "@pipecat-ai/client-js@~$INSTALL_SPEC"
+                npm install --save-dev "@pipecat-ai/client-js@^$INSTALL_SPEC"
+            else
+                # Use npm package installation
+                npm install "@pipecat-ai/client-js@^$INSTALL_SPEC"
+            fi
+        fi
+        cd - > /dev/null
+    else
+        echo "Skipping $dir (no package.json found)"
+    fi
+}
+
+# Install in top-level directory
+echo "=== Installing in top-level directory ==="
+install_in_dir "."
+
+# Install in all transport directories
+echo "=== Installing in transport directories ==="
+for transport_dir in transports/*/; do
+    if [ -d "$transport_dir" ]; then
+        install_in_dir "$transport_dir"
+    fi
+done
+
+# Install in all example directories
+echo "=== Installing in example directories ==="
+for example_dir in examples/*/; do
+    if [ -d "$example_dir" ]; then
+        install_in_dir "$example_dir"
+    fi
+done
+
+echo "=== Installation complete! ==="
+echo "Package specification used: $INSTALL_SPEC"

--- a/transports/daily/package.json
+++ b/transports/daily/package.json
@@ -21,13 +21,13 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "^1.1.0",
+    "@pipecat-ai/client-js": "^1.2.0",
     "eslint": "9.11.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~1.1.0"
+    "@pipecat-ai/client-js": "~1.2.0"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.77.0"

--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -425,11 +425,20 @@ export class DailyTransport extends Transport {
     }
     type DailyConnectParams = DailyCallOptions & {
       room_url?: string;
+      dailyRoom?: string; // for compatibility with old PipecatCloud versions
+      dailyToken?: string; // for compatibility with old PipecatCloud versions
     };
     const tmpParams = connectParams as DailyConnectParams;
     if (tmpParams.room_url) {
       tmpParams.url = tmpParams.room_url;
       delete tmpParams.room_url;
+    } else if (tmpParams.dailyRoom) {
+      tmpParams.url = tmpParams.dailyRoom;
+      delete tmpParams.dailyRoom;
+    }
+    if (tmpParams.dailyToken) {
+      tmpParams.token = tmpParams.dailyToken;
+      delete tmpParams.dailyToken;
     }
     if (!tmpParams.token) {
       // Daily doesn't like token being in the map and undefined or null

--- a/transports/gemini-live-websocket-transport/package.json
+++ b/transports/gemini-live-websocket-transport/package.json
@@ -24,14 +24,14 @@
     "@daily-co/daily-js": "^0.79.0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "^1.1.0",
+    "@pipecat-ai/client-js": "^1.2.0",
     "@types/node": "^22.9.0",
     "eslint": "9.11.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~1.1.0"
+    "@pipecat-ai/client-js": "~1.2.0"
   },
   "description": "Pipecat Gemini Multimodal Live Transport Package",
   "author": "Daily.co",

--- a/transports/openai-realtime-webrtc-transport/package.json
+++ b/transports/openai-realtime-webrtc-transport/package.json
@@ -21,14 +21,14 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "^1.1.0",
+    "@pipecat-ai/client-js": "^1.2.0",
     "@types/node": "^22.9.0",
     "eslint": "9.11.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~1.1.0"
+    "@pipecat-ai/client-js": "~1.2.0"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.77.0",

--- a/transports/small-webrtc-transport/package.json
+++ b/transports/small-webrtc-transport/package.json
@@ -22,14 +22,14 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "^1.1.0",
+    "@pipecat-ai/client-js": "^1.2.0",
     "@types/node": "^22.9.0",
     "eslint": "9.11.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~1.1.0"
+    "@pipecat-ai/client-js": "~1.2.0"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.77.0",

--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -98,11 +98,11 @@ export class SmallWebRTCTransport extends Transport {
 
   constructor(opts: SmallWebRTCTransportConstructorOptions = {}) {
     super();
-    this._iceServers = opts.iceServers || [];
-    this._waitForICEGathering = opts.waitForICEGathering || false;
-    this._webrtcUrl = opts.webrtc_url || opts.connectionUrl || null;
-    this.audioCodec = opts.audioCodec || null;
-    this.videoCodec = opts.videoCodec || null;
+    this._iceServers = opts.iceServers ?? [];
+    this._waitForICEGathering = opts.waitForICEGathering ?? false;
+    this._webrtcUrl = opts.webrtc_url ?? opts.connectionUrl ?? null;
+    this.audioCodec = opts.audioCodec ?? null;
+    this.videoCodec = opts.videoCodec ?? null;
 
     if (opts.connectionUrl) {
       logger.warn("connectionUrl is deprecated, use webrtc_url instead");
@@ -191,8 +191,8 @@ export class SmallWebRTCTransport extends Transport {
     this.state = "connecting";
 
     this._webrtcUrl =
-      connectParams?.webrtc_url ||
-      connectParams?.connectionUrl ||
+      connectParams?.webrtc_url ??
+      connectParams?.connectionUrl ??
       this._webrtcUrl;
     if (!this._webrtcUrl) {
       logger.error("No url provided for connection");

--- a/transports/websocket-transport/package.json
+++ b/transports/websocket-transport/package.json
@@ -22,14 +22,14 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "^1.1.0",
+    "@pipecat-ai/client-js": "^1.2.0",
     "@types/node": "^22.9.0",
     "eslint": "9.11.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~1.1.0"
+    "@pipecat-ai/client-js": "~1.2.0"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.79.0",

--- a/transports/websocket-transport/src/webSocketTransport.ts
+++ b/transports/websocket-transport/src/webSocketTransport.ts
@@ -17,7 +17,9 @@ import { WebSocketSerializer } from "./serializers/websocketSerializer.ts";
 import { ProtobufFrameSerializer } from "./serializers/protobufSerializer.ts";
 
 export type WebSocketTransportOptions = {
+  /** @deprecated Use wsUrl instead */
   ws_url?: string;
+  wsUrl?: string;
   serializer?: WebSocketSerializer;
   recorderSampleRate?: number;
   playerSampleRate?: number;
@@ -40,9 +42,9 @@ export class WebSocketTransport extends Transport {
 
   constructor(opts: WebSocketTransportConstructorOptions = {}) {
     super();
-    this._wsUrl = opts.ws_url || null;
+    this._wsUrl = opts.wsUrl ?? opts.ws_url ?? null;
     this._recorderSampleRate =
-      opts.recorderSampleRate || WebSocketTransport.RECORDER_SAMPLE_RATE;
+      opts.recorderSampleRate ?? WebSocketTransport.RECORDER_SAMPLE_RATE;
     this._mediaManager =
       opts.mediaManager ||
       new DailyMediaManager(
@@ -52,7 +54,7 @@ export class WebSocketTransport extends Transport {
         undefined,
         512,
         this._recorderSampleRate,
-        opts.playerSampleRate || WebSocketTransport.PLAYER_SAMPLE_RATE,
+        opts.playerSampleRate ?? WebSocketTransport.PLAYER_SAMPLE_RATE,
       );
     this._mediaManager.setUserAudioCallback(
       this.handleUserAudioStream.bind(this),
@@ -87,21 +89,28 @@ export class WebSocketTransport extends Transport {
     if (typeof connectParams !== "object") {
       throw new RTVIError("Invalid connection parameters");
     }
-    const fixedParams = {} as WebSocketTransportOptions;
+    const snakeToCamel = (snakeCaseString: string) => {
+      return snakeCaseString.replace(/_([a-z,A-Z])/g, (_, letter) =>
+        letter.toUpperCase(),
+      );
+    };
+    const fixedParams: WebSocketTransportOptions = {};
     for (const [key, val] of Object.entries(connectParams)) {
-      // acept ws_url for backwards compatibility
-      if (key === "ws_url" || key === "connectionUrl") {
+      const camelKey = snakeToCamel(key);
+      if (camelKey === "wsUrl") {
         if (typeof val !== "string") {
           throw new RTVIError(
-            `Invalid type for connectionUrl: expected string, got ${typeof val}`,
+            `Invalid type for wsUrl: expected string, got ${typeof val}`,
           );
         }
-        fixedParams.ws_url = val;
-      } else {
-        throw new RTVIError(
-          `Unrecognized connection parameter: ${key}. Only 'connectionUrl' is allowed.`,
-        );
+      } else if (
+        !["serializer", "recorderSampleRate", "playerSampleRate"].includes(
+          camelKey,
+        )
+      ) {
+        throw new RTVIError(`Unrecognized connection parameter: ${key}.`);
       }
+      fixedParams[camelKey as keyof WebSocketTransportOptions] = val;
     }
     return fixedParams as WebSocketTransportOptions;
   }

--- a/transports/websocket-transport/src/webSocketTransport.ts
+++ b/transports/websocket-transport/src/webSocketTransport.ts
@@ -20,14 +20,14 @@ export type WebSocketTransportOptions = {
   /** @deprecated Use wsUrl instead */
   ws_url?: string;
   wsUrl?: string;
-  serializer?: WebSocketSerializer;
-  recorderSampleRate?: number;
-  playerSampleRate?: number;
 };
 
 export interface WebSocketTransportConstructorOptions
   extends WebSocketTransportOptions {
   mediaManager?: MediaManager;
+  serializer?: WebSocketSerializer;
+  recorderSampleRate?: number;
+  playerSampleRate?: number;
 }
 
 export class WebSocketTransport extends Transport {
@@ -103,11 +103,7 @@ export class WebSocketTransport extends Transport {
             `Invalid type for wsUrl: expected string, got ${typeof val}`,
           );
         }
-      } else if (
-        !["serializer", "recorderSampleRate", "playerSampleRate"].includes(
-          camelKey,
-        )
-      ) {
+      } else {
         throw new RTVIError(`Unrecognized connection parameter: ${key}.`);
       }
       fixedParams[camelKey as keyof WebSocketTransportOptions] = val;
@@ -120,7 +116,7 @@ export class WebSocketTransport extends Transport {
 
     this.state = "connecting";
 
-    this._wsUrl = connectParams?.ws_url || this._wsUrl;
+    this._wsUrl = connectParams?.wsUrl ?? connectParams?.ws_url ?? this._wsUrl;
     if (!this._wsUrl) {
       logger.error("No url provided for connection");
       this.state = "error";


### PR DESCRIPTION
to avoid confusion with `endpoint` and better align with other transports' naming for the url to communicate across (DailyTransport: `room_url`, and WebsocketTransport: `ws_url`), this deprecates the `connectionUrl` field name to promote a replacement of `webrtc_url`

**UPDATE**:

To be consistent with camelCasing, this is updating `ws_url` to be `wsUrl` and using `webrtcUrl` instead of `webrtc_url`. The validation step, however, is fixed so that either can be passed in in order to support existing examples and servers that really want to do everything in snake_case.

ALSO: Since we're touching the various validation methods, this updates Daily's validation to accept the current PipecatClout behavior of returning `dailyRoom`/`dailyToken`, thought that _should_ be updated in time to return simply `url`/`token`.