### PR TITLE
Fixed an issue in `startBotAndConnect` where `requestData` was not carried over when invoking the `connect` endpoint.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3389,7 +3389,7 @@
     },
     "transports/small-webrtc-transport": {
       "name": "@pipecat-ai/small-webrtc-transport",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.83.1",

--- a/transports/small-webrtc-transport/CHANGELOG.md
+++ b/transports/small-webrtc-transport/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to **Pipecat Small WebRTC Transport** will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1]
+
+- Fixed an issue in `startBotAndConnect` where `requestData` was not carried over when invoking the `connect` endpoint.
+
 ## [1.7.0]
 
 - Allowing `startBotAndConnect` to work with Pipecat Cloud and Pipecat runner.

--- a/transports/small-webrtc-transport/package.json
+++ b/transports/small-webrtc-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipecat-ai/small-webrtc-transport",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "BSD-2-Clause",
   "main": "dist/index.js",
   "module": "dist/index.module.js",

--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -308,6 +308,7 @@ export class SmallWebRTCTransport extends Transport {
     return {
       endpoint: offerUrl,
       headers: this.startBotParams!.headers,
+      requestData: this.startBotParams!.requestData,
     };
   }
 


### PR DESCRIPTION
Fixed an issue in `startBotAndConnect` where `requestData` was not carried over when invoking the `connect` endpoint.