### PR TITLE
Modified `startBotAndConnect` method to handle request data differently for internal endpoint calls.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3389,7 +3389,7 @@
     },
     "transports/small-webrtc-transport": {
       "name": "@pipecat-ai/small-webrtc-transport",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.83.1",

--- a/transports/small-webrtc-transport/CHANGELOG.md
+++ b/transports/small-webrtc-transport/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to **Pipecat Small WebRTC Transport** will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2]
+
+### Changed
+- Modified `startBotAndConnect` method to handle request data differently for internal endpoint calls:
+  - When calling the `start` endpoint: sends the complete `requestData` object (including all properties like `createDailyRoom`, `enableDefaultIceServers`, etc.)
+  - When calling the `connect` endpoint: only sends the data contained within the `body` property of `requestData`
+  
+  **Example:** If `startBotAndConnect` is called with:
+  ```
+    requestData: {
+      createDailyRoom: false,
+      enableDefaultIceServers: true,
+      body: { character_id: characterId }
+    }
+  ```
+  The `start` endpoint receives the full object, while the `connect` endpoint only receives `{ character_id: characterId }`.
+
 ## [1.7.1]
 
 - Fixed an issue in `startBotAndConnect` where `requestData` was not carried over when invoking the `connect` endpoint.

--- a/transports/small-webrtc-transport/package.json
+++ b/transports/small-webrtc-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipecat-ai/small-webrtc-transport",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "BSD-2-Clause",
   "main": "dist/index.js",
   "module": "dist/index.module.js",

--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -305,10 +305,13 @@ export class SmallWebRTCTransport extends Transport {
       "/start",
       `/sessions/${sessionId}/api/offer`,
     );
+    const offerRequestData = this.startBotParams!.requestData
+      ? (this.startBotParams!.requestData as any).body
+      : undefined;
     return {
       endpoint: offerUrl,
       headers: this.startBotParams!.headers,
-      requestData: this.startBotParams!.requestData,
+      requestData: offerRequestData,
     };
   }
 


### PR DESCRIPTION
Modified `startBotAndConnect` method to handle request data differently for internal endpoint calls.