### PR TITLE
feat: add livekit transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Docs](https://img.shields.io/badge/Documentation-blue)](https://docs.pipecat.ai/client/js/transports/transport)
 [![Discord](https://img.shields.io/discord/1239284677165056021)](https://discord.gg/pipecat)
 
-A mono-repo to house the various supported Transport options to be used with the pipecat-client-web library. Currently, there are six transports: `small-webrtc-transport`, `daily-transport`, `websocket-transport`, `gemini-live-websocket-transport`, `openai-realtime-webrtc-transport`, and `moq-transport`.
+A mono-repo to house the various supported Transport options to be used with the pipecat-client-web library. Currently, there are seven transports: `small-webrtc-transport`, `daily-transport`, `websocket-transport`, `gemini-live-websocket-transport`, `openai-realtime-webrtc-transport`, `livekit-transport` and `moq-transport`.
 
 ## Documentation
 
@@ -21,31 +21,33 @@ Pipecat Transports are intended to be used in conjunction with a Pipecat web cli
 This Transport creates a peer-to-peer WebRTC connection between the client and the bot process. This Transport is the client-side counterpart to the Pipecat [SmallWebRTCTransport component](https://docs.pipecat.ai/server/services/transport/small-webrtc).
 
 This is the simplest low-latency audio/video transport for Pipecat. This transport is recommended for local development and demos. Things to be aware of:
+
 - This transport is a direct connection between the client and the bot process. If you need multiple clients to connect to the same bot, you will need to use a different transport.
 - For production usage at scale, a distributed WebRTC network that can do edge/mesh routing, has session-level observability and metrics, and can offload recording and other auxiliary services is often useful.
 
 Typical media flow using a SmallWebRTCTransport:
+
 ```
-                                            ┌──────────────────────────────────────────────────┐ 
-                                            │                                                  │ 
- ┌─────────────────────────┐                │                       Server       ┌─────────┐   │ 
- │                         │                │                                    │Pipecat  │   │ 
- │            Client       │  RTVI Messages │                                    │Pipeline │   │ 
- │                         │       &        │                                              │   │ 
- │ ┌────────────────────┐  │  WebRTC Media  │  ┌────────────────────┐    media   │ ┌─────┐ │   │ 
- │ │SmallWebRTCTransport│◄─┼────────────────┼─►│SmallWebRTCTransport┼────────────┼─► STT │ │   │ 
- │ └────────────────────┘  │                │  └───────▲────────────┘     in     │ └──┬──┘ │   │ 
- │                         │                │          │                         │    │    │   │ 
- └─────────────────────────┘                │          │                         │ ┌──▼──┐ │   │ 
-                                            │          │                         │ │ LLM │ │   │ 
-                                            │          │                         │ └──┬──┘ │   │ 
-                                            │          │                         │    │    │   │ 
-                                            │          │                         │ ┌──▼──┐ │   │ 
-                                            │          │           media         │ │ TTS │ │   │ 
-                                            │          └─────────────────────────┼─┴─────┘ │   │ 
-                                            │                       out          └─────────┘   │ 
-                                            │                                                  │ 
-                                            └──────────────────────────────────────────────────┘ 
+                                            ┌──────────────────────────────────────────────────┐
+                                            │                                                  │
+ ┌─────────────────────────┐                │                       Server       ┌─────────┐   │
+ │                         │                │                                    │Pipecat  │   │
+ │            Client       │  RTVI Messages │                                    │Pipeline │   │
+ │                         │       &        │                                              │   │
+ │ ┌────────────────────┐  │  WebRTC Media  │  ┌────────────────────┐    media   │ ┌─────┐ │   │
+ │ │SmallWebRTCTransport│◄─┼────────────────┼─►│SmallWebRTCTransport┼────────────┼─► STT │ │   │
+ │ └────────────────────┘  │                │  └───────▲────────────┘     in     │ └──┬──┘ │   │
+ │                         │                │          │                         │    │    │   │
+ └─────────────────────────┘                │          │                         │ ┌──▼──┐ │   │
+                                            │          │                         │ │ LLM │ │   │
+                                            │          │                         │ └──┬──┘ │   │
+                                            │          │                         │    │    │   │
+                                            │          │                         │ ┌──▼──┐ │   │
+                                            │          │           media         │ │ TTS │ │   │
+                                            │          └─────────────────────────┼─┴─────┘ │   │
+                                            │                       out          └─────────┘   │
+                                            │                                                  │
+                                            └──────────────────────────────────────────────────┘
 ```
 
 ### [DailyTransport](/transports/daily/README.md)
@@ -58,43 +60,84 @@ Typical media flow using a SmallWebRTCTransport:
 This Transport uses the [Daily](https://daily.co) audio and video calling service to connect to a bot and stream media over a WebRTC connection. This Transport is the client-side counterpart to the Pipecat [DailyTransport component](https://docs.pipecat.ai/server/services/transport/daily).
 
 Typical media flow using a DailyTransport:
-```
-                                                                                       
-                                       ┌────────────────────────────────────────────┐  
-                                       │                                            │  
-  ┌───────────────────┐                │                 Server       ┌─────────┐   │  
-  │                   │                │                              │Pipecat  │   │  
-  │      Client       │  RTVI Messages │                              │Pipeline │   │  
-  │                   │       &        │                              │         │   │  
-  │ ┌──────────────┐  │  WebRTC Media  │  ┌──────────────┐    media   │ ┌─────┐ │   │  
-  │ │DailyTransport│◄─┼────────────────┼─►│DailyTransport┼────────────┼─► STT │ │   │  
-  │ └──────────────┘  │                │  └───────▲──────┘     in     │ └──┬──┘ │   │  
-  │                   │                │          │                   │    │    │   │  
-  └───────────────────┘                │          │                   │ ┌──▼──┐ │   │  
-                                       │          │                   │ │ LLM │ │   │  
-                                       │          │                   │ └──┬──┘ │   │  
-                                       │          │                   │    │    │   │  
-                                       │          │                   │ ┌──▼──┐ │   │  
-                                       │          │     media         │ │ TTS │ │   │  
-                                       │          └───────────────────┼─┴─────┘ │   │  
-                                       │                 out          └─────────┘   │  
-                                       │                                            │  
-                                       └────────────────────────────────────────────┘  
-                                                                                       
+
 ```
 
+                                       ┌────────────────────────────────────────────┐
+                                       │                                            │
+  ┌───────────────────┐                │                 Server       ┌─────────┐   │
+  │                   │                │                              │Pipecat  │   │
+  │      Client       │  RTVI Messages │                              │Pipeline │   │
+  │                   │       &        │                              │         │   │
+  │ ┌──────────────┐  │  WebRTC Media  │  ┌──────────────┐    media   │ ┌─────┐ │   │
+  │ │DailyTransport│◄─┼────────────────┼─►│DailyTransport┼────────────┼─► STT │ │   │
+  │ └──────────────┘  │                │  └───────▲──────┘     in     │ └──┬──┘ │   │
+  │                   │                │          │                   │    │    │   │
+  └───────────────────┘                │          │                   │ ┌──▼──┐ │   │
+                                       │          │                   │ │ LLM │ │   │
+                                       │          │                   │ └──┬──┘ │   │
+                                       │          │                   │    │    │   │
+                                       │          │                   │ ┌──▼──┐ │   │
+                                       │          │     media         │ │ TTS │ │   │
+                                       │          └───────────────────┼─┴─────┘ │   │
+                                       │                 out          └─────────┘   │
+                                       │                                            │
+                                       └────────────────────────────────────────────┘
+
+```
+
+<<<<<<< HEAD
+
 ### [WebSocketTransport](transports/websocket-transport/README.md)
+
 [![Docs](https://img.shields.io/badge/Documentation-blue)](https://docs.pipecat.ai/api-reference/client/js/transports/websocket)
 [![README](https://img.shields.io/badge/README-goldenrod)](transports/websocket-transport/README.md)
 [![Demo](https://img.shields.io/badge/Demo-forestgreen)](https://github.com/pipecat-ai/pipecat-examples/tree/main/websocket)
 [![NPM Version](https://img.shields.io/npm/v/@pipecat-ai/websocket-transport)](https://www.npmjs.com/package/@pipecat-ai/websocket-transport)
 
-
 This transport enables a purely WebSocket based connection between clients and your Pipecat application. It implements bidirectional audio and video streaming using a WebSocket for real-time communication.
 
-It is intended for lightweight implementations, particularly for local development and testing. It expects your Pipecat server to include the corresponding server-side [WebSocketTransport](https://docs.pipecat.ai/api-reference/server/services/transport/websocket-server) implementation.
+# It is intended for lightweight implementations, particularly for local development and testing. It expects your Pipecat server to include the corresponding server-side [WebSocketTransport](https://docs.pipecat.ai/api-reference/server/services/transport/websocket-server) implementation.
+
+### [LiveKitTransport](/transports/livekit-transport/README.md)
+
+[![Docs](https://img.shields.io/badge/Documentation-blue)](https://docs.pipecat.ai/client/js/transports/livekit)
+[![README](https://img.shields.io/badge/README-goldenrod)](/transports/livekit-transport/README.md)
+![NPM Version](https://img.shields.io/npm/v/@pipecat-ai/livekit-transport)
+
+This Transport uses the [LiveKit](https://livekit.io) real-time communication platform to connect to a bot and stream media over a WebRTC connection. LiveKit provides a scalable, distributed WebRTC infrastructure with features like edge routing, session observability, and recording capabilities.
+
+Typical media flow using a LiveKitTransport:
+
+```
+
+                                       ┌────────────────────────────────────────────┐
+                                       │                                            │
+  ┌───────────────────┐                │                 Server       ┌─────────┐   │
+  │                   │                │                              │Pipecat  │   │
+  │      Client       │  RTVI Messages │                              │Pipeline │   │
+  │                   │       &        │                              │         │   │
+  │ ┌──────────────┐  │  WebRTC Media  │  ┌──────────────┐    media   │ ┌─────┐ │   │
+  │ │LiveKitTranspo│◄─┼────────────────┼─►│LiveKitTranspo┼────────────┼─► STT │ │   │
+  │ └──────────────┘  │                │  └───────▲──────┘     in     │ └──┬──┘ │   │
+  │                   │                │          │                   │    │    │   │
+  └───────────────────┘                │          │                   │ ┌──▼──┐ │   │
+                                       │          │                   │ │ LLM │ │   │
+                                       │          │                   │ └──┬──┘ │   │
+                                       │          │                   │    │    │   │
+                                       │          │                   │ ┌──▼──┐ │   │
+                                       │          │     media         │ │ TTS │ │   │
+                                       │          └───────────────────┼─┴─────┘ │   │
+                                       │                 out          └─────────┘   │
+                                       │                                            │
+                                       └────────────────────────────────────────────┘
+
+```
+
+> > > > > > > e6ded27 (feat: add livekit transport)
 
 ### [GeminiLiveWebSocketTransport](transports/gemini-live-websocket-transport/README.md)
+
 [![Docs](https://img.shields.io/badge/Documentation-blue)](https://docs.pipecat.ai/client/js/transports/gemini)
 [![README](https://img.shields.io/badge/README-goldenrod)](transports/gemini-live-websocket-transport/README.md)
 [![Demo](https://img.shields.io/badge/Demo-forestgreen)](examples/directToLLMTransports/README.md)
@@ -103,20 +146,22 @@ It is intended for lightweight implementations, particularly for local developme
 This Transport extends the [RealTimeWebSocketTransport](transports/realtime-websocket-transport/README) and connects directly to Gemini over a WebSocket connection using the Multimodal Live API. This type of transport is great for testing different services out without the need to build a server component. Just be aware that it is insecure since you will need to have access to your Gemini API Key client-side so not probably something you want to use in your production app.
 
 Media flow using a GeminiLiveWebSocketTransport:
+
 ```
-                Client                                      Server        
-  ┌────────────────────────────────────┐                                  
-  │                                    │                                  
-  │           PipecatClient            │                ┌──────────────┐  
-  │                                    │    Media over  │              │  
-  │  ┌──────────────────────────────┐  │    WebSocket   │    Gemini    │  
-  │  │ GeminiLiveWebSocketTransport │◄─┼────────────────┼─►  Server    │  
-  │  └──────────────────────────────┘  │                │              │  
-  │                                    │                └──────────────┘  
-  └────────────────────────────────────┘                                  
+                Client                                      Server
+  ┌────────────────────────────────────┐
+  │                                    │
+  │           PipecatClient            │                ┌──────────────┐
+  │                                    │    Media over  │              │
+  │  ┌──────────────────────────────┐  │    WebSocket   │    Gemini    │
+  │  │ GeminiLiveWebSocketTransport │◄─┼────────────────┼─►  Server    │
+  │  └──────────────────────────────┘  │                │              │
+  │                                    │                └──────────────┘
+  └────────────────────────────────────┘
 ```
 
 ### [OpenAIRealTimeWebRTCTransport](transports/gemini-live-websocket-transport/README.md)
+
 [![Docs](https://img.shields.io/badge/Documentation-blue)](https://docs.pipecat.ai/client/js/transports/openai-webrtc)
 [![README](https://img.shields.io/badge/README-goldenrod)](transports/openai-realtime-webrtc-transport/README.md)
 [![Demo](https://img.shields.io/badge/Demo-forestgreen)](examples/directToLLMTransports/README.md)
@@ -125,17 +170,18 @@ Media flow using a GeminiLiveWebSocketTransport:
 This Transport connects directly to OpenAI over a WebRTC connection using the RealTime API. This type of transport is great for testing different services out without the need to build a server component. Just be aware that it is insecure since you will need to have access to your OpenAI API Key client-side so not probably something you want to use in your production app. It does not implement the Ephemeral Token process.
 
 Media flow using a OpenAIRealTimeWebRTCTransport:
+
 ```
-                Client                                      Server        
-  ┌─────────────────────────────────────┐                                  
-  │                                     │                                  
-  │          PipecatClient              │                ┌──────────────┐  
-  │                                     │    Media over  │              │  
-  │  ┌───────────────────────────────┐  │      WebRTC    │    OpenAI    │  
-  │  │ OpenAIRealTimeWebRTCTransport │◄─┼────────────────┼─►  Server    │  
-  │  └───────────────────────────────┘  │                │              │  
-  │                                     │                └──────────────┘  
-  └─────────────────────────────────────┘                                  
+                Client                                      Server
+  ┌─────────────────────────────────────┐
+  │                                     │
+  │          PipecatClient              │                ┌──────────────┐
+  │                                     │    Media over  │              │
+  │  ┌───────────────────────────────┐  │      WebRTC    │    OpenAI    │
+  │  │ OpenAIRealTimeWebRTCTransport │◄─┼────────────────┼─►  Server    │
+  │  └───────────────────────────────┘  │                │              │
+  │                                     │                └──────────────┘
+  └─────────────────────────────────────┘
 ```
 
 ### [MoqTransport](/transports/moq-transport/README.md)
@@ -148,29 +194,30 @@ Media flow using a OpenAIRealTimeWebRTCTransport:
 This Transport uses [Media over QUIC (MoQ)](https://quic.video/) to connect to a bot, either through a MoQ relay or directly to a bot running in serve mode. This Transport is the client-side counterpart to the Pipecat MoQ transport component (`pipecat.transports.moq.transport`).
 
 Typical media flow using a MoqTransport:
+
 ```
-                                                                                       
-                                       ┌────────────────────────────────────────────┐  
-                                       │                                            │  
-  ┌───────────────────┐                │                 Server       ┌─────────┐   │  
-  │                   │                │                              │Pipecat  │   │  
-  │      Client       │  RTVI Messages │                              │Pipeline │   │  
-  │                   │       &        │                              │         │   │  
-  │ ┌──────────────┐  │  WebTransport  │  ┌──────────────┐    media   │ ┌─────┐ │   │  
-  │ │ MoqTransport │◄─┼────────────────┼─►│ MoqTransport ┼────────────┼─► STT │ │   │  
-  │ └──────────────┘  │                │  └───────▲──────┘     in     │ └──┬──┘ │   │  
-  │                   │                │          │                   │    │    │   │  
-  └───────────────────┘                │          │                   │ ┌──▼──┐ │   │  
-                                       │          │                   │ │ LLM │ │   │  
-                                       │          │                   │ └──┬──┘ │   │  
-                                       │          │                   │    │    │   │  
-                                       │          │                   │ ┌──▼──┐ │   │  
-                                       │          │     media         │ │ TTS │ │   │  
-                                       │          └───────────────────┼─┴─────┘ │   │  
-                                       │                 out          └─────────┘   │  
-                                       │                                            │  
-                                       └────────────────────────────────────────────┘  
-                                                                                       
+
+                                       ┌────────────────────────────────────────────┐
+                                       │                                            │
+  ┌───────────────────┐                │                 Server       ┌─────────┐   │
+  │                   │                │                              │Pipecat  │   │
+  │      Client       │  RTVI Messages │                              │Pipeline │   │
+  │                   │       &        │                              │         │   │
+  │ ┌──────────────┐  │  WebTransport  │  ┌──────────────┐    media   │ ┌─────┐ │   │
+  │ │ MoqTransport │◄─┼────────────────┼─►│ MoqTransport ┼────────────┼─► STT │ │   │
+  │ └──────────────┘  │                │  └───────▲──────┘     in     │ └──┬──┘ │   │
+  │                   │                │          │                   │    │    │   │
+  └───────────────────┘                │          │                   │ ┌──▼──┐ │   │
+                                       │          │                   │ │ LLM │ │   │
+                                       │          │                   │ └──┬──┘ │   │
+                                       │          │                   │    │    │   │
+                                       │          │                   │ ┌──▼──┐ │   │
+                                       │          │     media         │ │ TTS │ │   │
+                                       │          └───────────────────┼─┴─────┘ │   │
+                                       │                 out          └─────────┘   │
+                                       │                                            │
+                                       └────────────────────────────────────────────┘
+
 ```
 
 ## Local Development
@@ -183,9 +230,11 @@ $ npm run build
 ```
 
 ## License
+
 BSD-2 Clause
 
 ## Contributing
+
 We welcome contributions from the community! Whether you're fixing bugs, improving documentation, or adding new features, here's how you can help:
 
 - **Found a bug?** Open an [issue](https://github.com/pipecat-ai/pipecat-client-web-transports/issues)

--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ Typical media flow using a DailyTransport:
 
 ```
 
-<<<<<<< HEAD
-
 ### [WebSocketTransport](transports/websocket-transport/README.md)
 
 [![Docs](https://img.shields.io/badge/Documentation-blue)](https://docs.pipecat.ai/api-reference/client/js/transports/websocket)
@@ -97,7 +95,7 @@ Typical media flow using a DailyTransport:
 
 This transport enables a purely WebSocket based connection between clients and your Pipecat application. It implements bidirectional audio and video streaming using a WebSocket for real-time communication.
 
-# It is intended for lightweight implementations, particularly for local development and testing. It expects your Pipecat server to include the corresponding server-side [WebSocketTransport](https://docs.pipecat.ai/api-reference/server/services/transport/websocket-server) implementation.
+It is intended for lightweight implementations, particularly for local development and testing. It expects your Pipecat server to include the corresponding server-side [WebSocketTransport](https://docs.pipecat.ai/api-reference/server/services/transport/websocket-server) implementation.
 
 ### [LiveKitTransport](/transports/livekit-transport/README.md)
 
@@ -105,7 +103,7 @@ This transport enables a purely WebSocket based connection between clients and y
 [![README](https://img.shields.io/badge/README-goldenrod)](/transports/livekit-transport/README.md)
 ![NPM Version](https://img.shields.io/npm/v/@pipecat-ai/livekit-transport)
 
-This Transport uses the [LiveKit](https://livekit.io) real-time communication platform to connect to a bot and stream media over a WebRTC connection. LiveKit provides a scalable, distributed WebRTC infrastructure with features like edge routing, session observability, and recording capabilities.
+This Transport uses the [LiveKit](https://livekit.io) real-time communication platform to connect to a bot and stream media over a WebRTC connection. This Transport is the client-side counterpart to the Pipecat [LiveKitTransport component](https://docs.pipecat.ai/server/services/transport/livekit).
 
 Typical media flow using a LiveKitTransport:
 
@@ -133,8 +131,6 @@ Typical media flow using a LiveKitTransport:
                                        └────────────────────────────────────────────┘
 
 ```
-
-> > > > > > > e6ded27 (feat: add livekit transport)
 
 ### [GeminiLiveWebSocketTransport](transports/gemini-live-websocket-transport/README.md)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -49,8 +47,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -58,22 +54,22 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.2",
+      "version": "7.29.2",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.6.2",
+      "version": "2.12.0",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bufbuild/protoplugin": {
-      "version": "2.6.2",
+      "version": "2.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bufbuild/protobuf": "2.6.2",
-        "@typescript/vfs": "^1.5.2",
+        "@bufbuild/protobuf": "2.12.0",
+        "@typescript/vfs": "^1.6.2",
         "typescript": "5.4.5"
       }
     },
@@ -89,17 +85,15 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.2.tgz",
-      "integrity": "sha512-YjYSX2yj/WsVoxh9mNiymfFS2ADbg2EK4+1WAsMuckwKMCqJ5PDG0CJU/8GvmHWcv4VRB2V02KqSiecRksWqZQ==",
+      "version": "20.5.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/format": "^20.4.0",
-        "@commitlint/lint": "^20.4.2",
-        "@commitlint/load": "^20.4.0",
-        "@commitlint/read": "^20.4.0",
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/format": "^20.5.0",
+        "@commitlint/lint": "^20.5.0",
+        "@commitlint/load": "^20.5.2",
+        "@commitlint/read": "^20.5.0",
+        "@commitlint/types": "^20.5.0",
         "tinyexec": "^1.0.0",
         "yargs": "^17.0.0"
       },
@@ -111,65 +105,35 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.4.2.tgz",
-      "integrity": "sha512-rwkTF55q7Q+6dpSKUmJoScV0f3EpDlWKw2UPzklkLS4o5krMN1tPWAVOgHRtyUTMneIapLeQwaCjn44Td6OzBQ==",
+      "version": "20.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
-        "conventional-changelog-conventionalcommits": "^9.1.0"
+        "@commitlint/types": "^20.5.0",
+        "conventional-changelog-conventionalcommits": "^9.2.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.4.0.tgz",
-      "integrity": "sha512-zShmKTF+sqyNOfAE0vKcqnpvVpG0YX8F9G/ZIQHI2CoKyK+PSdladXMSns400aZ5/QZs+0fN75B//3Q5CHw++w==",
+      "version": "20.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/types": "^20.5.0",
         "ajv": "^8.11.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/config-validator/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@commitlint/config-validator/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@commitlint/ensure": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.1.tgz",
-      "integrity": "sha512-WLQqaFx1pBooiVvBrA1YfJNFqZF8wS/YGOtr5RzApDbV9tQ52qT5VkTsY65hFTnXhW8PcDfZLaknfJTmPejmlw==",
+      "version": "20.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/types": "^20.5.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -182,8 +146,6 @@
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
-      "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -191,13 +153,11 @@
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.4.0.tgz",
-      "integrity": "sha512-i3ki3WR0rgolFVX6r64poBHXM1t8qlFel1G1eCBvVgntE3fCJitmzSvH5JD/KVJN/snz6TfaX2CLdON7+s4WVQ==",
+      "version": "20.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/types": "^20.5.0",
         "picocolors": "^1.1.1"
       },
       "engines": {
@@ -205,13 +165,11 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.1.tgz",
-      "integrity": "sha512-In5EO4JR1lNsAv1oOBBO24V9ND1IqdAJDKZiEpdfjDl2HMasAcT7oA+5BKONv1pRoLG380DGPE2W2RIcUwdgLA==",
+      "version": "20.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
+        "@commitlint/types": "^20.5.0",
         "semver": "^7.6.0"
       },
       "engines": {
@@ -219,33 +177,29 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.2.tgz",
-      "integrity": "sha512-buquzNRtFng6xjXvBU1abY/WPEEjCgUipNQrNmIWe8QuJ6LWLtei/LDBAzEe5ASm45+Q9L2Xi3/GVvlj50GAug==",
+      "version": "20.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^20.4.1",
-        "@commitlint/parse": "^20.4.1",
-        "@commitlint/rules": "^20.4.2",
-        "@commitlint/types": "^20.4.0"
+        "@commitlint/is-ignored": "^20.5.0",
+        "@commitlint/parse": "^20.5.0",
+        "@commitlint/rules": "^20.5.0",
+        "@commitlint/types": "^20.5.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.4.0.tgz",
-      "integrity": "sha512-Dauup/GfjwffBXRJUdlX/YRKfSVXsXZLnINXKz0VZkXdKDcaEILAi9oflHGbfydonJnJAbXEbF3nXPm9rm3G6A==",
+      "version": "20.5.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^20.4.0",
+        "@commitlint/config-validator": "^20.5.0",
         "@commitlint/execute-rule": "^20.0.0",
-        "@commitlint/resolve-extends": "^20.4.0",
-        "@commitlint/types": "^20.4.0",
-        "cosmiconfig": "^9.0.0",
+        "@commitlint/resolve-extends": "^20.5.2",
+        "@commitlint/types": "^20.5.0",
+        "cosmiconfig": "^9.0.1",
         "cosmiconfig-typescript-loader": "^6.1.0",
         "is-plain-obj": "^4.1.0",
         "lodash.mergewith": "^4.6.2",
@@ -256,9 +210,7 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.0.tgz",
-      "integrity": "sha512-B5lGtvHgiLAIsK5nLINzVW0bN5hXv+EW35sKhYHE8F7V9Uz1fR4tx3wt7mobA5UNhZKUNgB/+ldVMQE6IHZRyA==",
+      "version": "20.4.3",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -266,30 +218,26 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.1.tgz",
-      "integrity": "sha512-XNtZjeRcFuAfUnhYrCY02+mpxwY4OmnvD3ETbVPs25xJFFz1nRo/25nHj+5eM+zTeRFvWFwD4GXWU2JEtoK1/w==",
+      "version": "20.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.4.0",
-        "conventional-changelog-angular": "^8.1.0",
-        "conventional-commits-parser": "^6.2.1"
+        "@commitlint/types": "^20.5.0",
+        "conventional-changelog-angular": "^8.2.0",
+        "conventional-commits-parser": "^6.3.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.4.0.tgz",
-      "integrity": "sha512-QfpFn6/I240ySEGv7YWqho4vxqtPpx40FS7kZZDjUJ+eHxu3azfhy7fFb5XzfTqVNp1hNoI3tEmiEPbDB44+cg==",
+      "version": "20.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/top-level": "^20.4.0",
-        "@commitlint/types": "^20.4.0",
-        "git-raw-commits": "^4.0.0",
+        "@commitlint/top-level": "^20.4.3",
+        "@commitlint/types": "^20.5.0",
+        "git-raw-commits": "^5.0.0",
         "minimist": "^1.2.8",
         "tinyexec": "^1.0.0"
       },
@@ -298,15 +246,13 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.4.0.tgz",
-      "integrity": "sha512-ay1KM8q0t+/OnlpqXJ+7gEFQNlUtSU5Gxr8GEwnVf2TPN3+ywc5DzL3JCxmpucqxfHBTFwfRMXxPRRnR5Ki20g==",
+      "version": "20.5.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^20.4.0",
-        "@commitlint/types": "^20.4.0",
-        "global-directory": "^4.0.1",
+        "@commitlint/config-validator": "^20.5.0",
+        "@commitlint/types": "^20.5.0",
+        "global-directory": "^5.0.0",
         "import-meta-resolve": "^4.0.0",
         "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0"
@@ -315,27 +261,15 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@commitlint/rules": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.2.tgz",
-      "integrity": "sha512-oz83pnp5Yq6uwwTAabuVQPNlPfeD2Y5ZjMb7Wx8FSUlu4sLYJjbBWt8031Z0osCFPfHzAwSYrjnfDFKtuSMdKg==",
+      "version": "20.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^20.4.1",
-        "@commitlint/message": "^20.4.0",
+        "@commitlint/ensure": "^20.5.0",
+        "@commitlint/message": "^20.4.3",
         "@commitlint/to-lines": "^20.0.0",
-        "@commitlint/types": "^20.4.0"
+        "@commitlint/types": "^20.5.0"
       },
       "engines": {
         "node": ">=v18"
@@ -343,8 +277,6 @@
     },
     "node_modules/@commitlint/to-lines": {
       "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
-      "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -352,9 +284,7 @@
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.0.tgz",
-      "integrity": "sha512-NDzq8Q6jmFaIIBC/GG6n1OQEaHdmaAAYdrZRlMgW6glYWGZ+IeuXmiymDvQNXPc82mVxq2KiE3RVpcs+1OeDeA==",
+      "version": "20.4.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -365,23 +295,44 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.4.0.tgz",
-      "integrity": "sha512-aO5l99BQJ0X34ft8b0h7QFkQlqxC6e7ZPVmBKz13xM9O8obDaM1Cld4sQlJDXXU/VFuUzQ30mVtHjVz74TuStw==",
+      "version": "20.5.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "conventional-commits-parser": "^6.2.1",
+        "conventional-commits-parser": "^6.3.0",
         "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=v18"
       }
     },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "2.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.2.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@daily-co/daily-js": {
       "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.90.0.tgz",
-      "integrity": "sha512-XnuuNIxLt8GOv+rFYoU+OPTSmVj+Mg9hRPK2EM6WYVY62F6rcw7vwzZBOSCisVuu1VnTIF/2J9V0VEBa83lDzw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -395,9 +346,7 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -415,8 +364,6 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -427,7 +374,7 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
+      "version": "4.12.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -435,15 +382,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -451,8 +396,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -464,8 +407,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -476,18 +417,18 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
+      "version": "3.3.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -497,10 +438,28 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/js": {
       "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -512,8 +471,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -522,8 +479,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -535,25 +490,33 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -572,8 +535,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -586,8 +547,6 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -602,16 +561,12 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "version": "1.5.2",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lezer/lr": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
-      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "version": "1.4.10",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -619,21 +574,38 @@
       }
     },
     "node_modules/@libav.js/types": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/@libav.js/types/-/types-6.8.8.tgz",
-      "integrity": "sha512-Lbik/0Q3x2R8cI7mOtRgt+nUWLqGXh7UinMndmpdXSDY4YEjYyVUDsq6fxkuriL78+LCYx8frZIN1r+oDsvYCQ==",
+      "version": "6.9.8",
+      "resolved": "https://registry.npmjs.org/@libav.js/types/-/types-6.9.8.tgz",
+      "integrity": "sha512-5EEW2IT2VYBYzq14+jsKh8LIwImD0ldsh7m0x/66WNvUG2QljUXsvYV5B00Scx5boVph3WYbtsiLmT0HfUIDRQ==",
       "license": "LGPL-2.1"
     },
     "node_modules/@libav.js/variant-opus-af": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/@libav.js/variant-opus-af/-/variant-opus-af-6.8.8.tgz",
-      "integrity": "sha512-8KBQyA8n5goN7lyctOaPxpcx7dapOgqKh8dWW/NAcl87AgM/WoUGSex3fFc46oCtTHYrUKEm1OmZUrtkt3Q56A==",
+      "version": "6.9.8",
+      "resolved": "https://registry.npmjs.org/@libav.js/variant-opus-af/-/variant-opus-af-6.9.8.tgz",
+      "integrity": "sha512-4v4kBOoNnmafubEiBof+ATtr7KcU2/kL+G2hXU61orvC4Lt5OViBXnHdUHCh5ZSQQSmx9nOFEgbYGGYTrBufXQ==",
       "license": "LGPL-2.1"
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.50.4",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz",
+      "integrity": "sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@livekit/protocol/node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
       "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.8.5.tgz",
-      "integrity": "sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==",
       "cpu": [
         "arm64"
       ],
@@ -642,82 +614,10 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-darwin-x64": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.8.5.tgz",
-      "integrity": "sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-linux-arm": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.8.5.tgz",
-      "integrity": "sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-linux-arm64": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.8.5.tgz",
-      "integrity": "sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-linux-x64": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.8.5.tgz",
-      "integrity": "sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@lmdb/lmdb-win32-x64": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.8.5.tgz",
-      "integrity": "sha512-4wvrf5BgnR8RpogHhtpCPJMKBmvyZPhhUtEwMJbXh0ni2BucpfF07jlmyM11zRqQ2XIq6PbC2j7W7UCCcm1rRQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@mischnic/json-sourcemap": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.1.tgz",
-      "integrity": "sha512-iA7+tyVqfrATAIsIRWQG+a7ZLLD0VaOCKV2Wd/v4mqIU3J9c4jx9p7S0nw1XH3gJCKNBOOwACOPYYSUu9pgT+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -739,19 +639,33 @@
       }
     },
     "node_modules/@moq/hang": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@moq/hang/-/hang-0.2.12.tgz",
-      "integrity": "sha512-rVz98b0l9adlwmSQ4O0kUW610N7M6zljR6wL5rqJP5gbTetbjI3NgA/xakFldRJN1NQnnVGtltYqbt2OuDfpVg==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@moq/hang/-/hang-0.2.16.tgz",
+      "integrity": "sha512-Zggd8Y4C6EVrVBc1+ZqXP04Hg9ymWYyD4YBimMSvufOr4PNHkz7QqRZMe1wrkw++pVq61iYuFalqyQdbXNaGpA==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
-        "@libav.js/variant-opus-af": "^6.8.8",
-        "@moq/json": "^0.1.1",
-        "@moq/loc": "^0.1.1",
-        "@moq/net": "^0.1.6",
+        "@libav.js/variant-opus-af": "^6.9.8",
+        "@moq/json": "^0.2.1",
+        "@moq/loc": "^0.1.2",
+        "@moq/net": "^0.1.9",
         "@moq/signals": "^0.1.10",
         "@svta/cml-iso-bmff": "^1.0.2",
         "zod": "^4.4.3"
+      }
+    },
+    "node_modules/@moq/hang/node_modules/@moq/json": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@moq/json/-/json-0.2.2.tgz",
+      "integrity": "sha512-7eKNczxuxMsfMrCYYneR+Y4C3MnzFS6hb+D94vwaIZbP0cxXHaGxzyGmUE0e3C7fLTC9W1jNR0pZbeC+IeFt2A==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/flate": "^0.1.1",
+        "@moq/net": "^0.1.9",
+        "@moq/signals": "^0.1.10"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@moq/json": {
@@ -769,28 +683,28 @@
       }
     },
     "node_modules/@moq/loc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@moq/loc/-/loc-0.1.1.tgz",
-      "integrity": "sha512-/DUgFYRmgHauxTaskPNn6tmv1UEYhuUk3bK4y67jZzAMy2N8sMZL6dyXuZvA2+n8jd/yZqy/pB+/+Tfj35JixQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@moq/loc/-/loc-0.1.2.tgz",
+      "integrity": "sha512-7hqereQwKCf6JMtKPKskgcSJC3naLQbB5/FsArKRUTMlQIF/QRu3gcaYflW8qSXaHrKm3hmpl7ra/oPLm4F7GA==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "@moq/net": "^0.1.5"
+        "@moq/net": "^0.1.7"
       }
     },
     "node_modules/@moq/msf": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@moq/msf/-/msf-0.1.3.tgz",
-      "integrity": "sha512-2Kxoniv7AgKdZfRMciUsEBELWAygzl8R89Dhn2t99qPIPwXn2yOlXEaOSoYVNvHIivbrSasIk09zRWUjSn2B8Q==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@moq/msf/-/msf-0.1.4.tgz",
+      "integrity": "sha512-cdAcWz3lFCnAu44nf4zsugAp0X84N8w/o/b5rynPMB/1uelXCdQpcbnYUK4kZhq0co8lDM28oAUOGwyL9BjIXg==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "@moq/net": "^0.1.6",
+        "@moq/net": "^0.1.7",
         "zod": "^4.4.3"
       }
     },
     "node_modules/@moq/net": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@moq/net/-/net-0.1.8.tgz",
-      "integrity": "sha512-pwx+GcqkH5M/kMk+/0SrXrwNOO8nV0B7bjkHcLD5q35c9FoQfrCwotsjodEEbND6LMDLGJiRUbWNR4gjIZjgyg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@moq/net/-/net-0.1.9.tgz",
+      "integrity": "sha512-S6qE57ZbUAd1+pem/BUMja2T/sKhXT5mjAqo063llbtIy5DOybe3XSjEhKGaLT+/GZVbISFAeTdnuohoeI7XYw==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@moq/qmux": "^0.1.3",
@@ -802,14 +716,14 @@
       }
     },
     "node_modules/@moq/publish": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@moq/publish/-/publish-0.2.16.tgz",
-      "integrity": "sha512-vgOCX4/VZYGzeStnwlPd6MY4hcXWAzDXSrNcjKHZdezu7hycfP++YwheVvP9c4ukfTWrqGfvdO+k8VLUTuuxSw==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/@moq/publish/-/publish-0.2.17.tgz",
+      "integrity": "sha512-6qDoh9FxEN3ee/raNnmQ4mTpnbhqcrzAQzft97tPVxZRgzie8vtTlRZYuDobRIYbz6iQ4tlpWuy1Fuc1xuDS6w==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "@moq/hang": "^0.2.12",
-        "@moq/json": "^0.1.1",
-        "@moq/net": "^0.1.6",
+        "@moq/hang": "^0.2.13",
+        "@moq/json": "^0.1.2",
+        "@moq/net": "^0.1.7",
         "@moq/signals": "^0.1.10"
       }
     },
@@ -845,28 +759,26 @@
       }
     },
     "node_modules/@moq/watch": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@moq/watch/-/watch-0.2.18.tgz",
-      "integrity": "sha512-6NfPr3qEfLG5Y1g60elEPpozzrda0kCHx+adoTUL7yAxYWs+MTARoSTWzdFLQCvF6nd1eVFkC0LaMKvxtyssvw==",
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@moq/watch/-/watch-0.2.19.tgz",
+      "integrity": "sha512-vSNcRUyOzUArabfMljf+DTP5gnM/Z0lSuZM/hoszLWK88PdU+ddckHF90q1IGg3pJl7Ti26voQ6ayFhM8bKFWA==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "@moq/hang": "^0.2.12",
-        "@moq/json": "^0.1.1",
-        "@moq/msf": "^0.1.3",
-        "@moq/net": "^0.1.6",
+        "@moq/hang": "^0.2.13",
+        "@moq/json": "^0.1.2",
+        "@moq/msf": "^0.1.4",
+        "@moq/net": "^0.1.7",
         "@moq/signals": "^0.1.10"
       }
     },
     "node_modules/@moq/web-socket-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@moq/web-socket-stream/-/web-socket-stream-0.1.0.tgz",
-      "integrity": "sha512-VxPaJZvZ8qgFmTjG9XhTH0bQoQE9pExvlS/R0fH1aNcpqCnZdbYS2kvB2ypO5SyFTf6oH+4eWvgElDzW6yiqFQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@moq/web-socket-stream/-/web-socket-stream-0.1.1.tgz",
+      "integrity": "sha512-VKi/GE/CLqmbEZlgNbBLbAFk2pQTxT+KUD2DjCSoxqZxbS3KBe5BBZ0m3fila4fEGyll2JT5MmgEyVr4zkZEVA==",
       "license": "(MIT OR Apache-2.0)"
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
       "cpu": [
         "arm64"
       ],
@@ -876,100 +788,9 @@
       "os": [
         "darwin"
       ]
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.129.0",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -978,8 +799,6 @@
     },
     "node_modules/@parcel/bundler-default": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.16.4.tgz",
-      "integrity": "sha512-Nb8peNvhfm1+660CLwssWh4weY+Mv6vEGS6GPKqzJmTMw50udi0eS1YuWFzvmhSiu1KsYcUD37mqQ1LuIDtWoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1001,8 +820,6 @@
     },
     "node_modules/@parcel/cache": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.16.4.tgz",
-      "integrity": "sha512-+uCyeElSga2MBbmbXpIj/WVKH7TByCrKaxtHbelfKKIJpYMgEHVjO4cuc7GUfTrUAmRUS8ZGvnX7Etgq6/jQhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1024,8 +841,6 @@
     },
     "node_modules/@parcel/codeframe": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.16.4.tgz",
-      "integrity": "sha512-s64aMfOJoPrXhKH+Y98ahX0O8aXWvTR+uNlOaX4yFkpr4FFDnviLcGngDe/Yo4Qq2FJZ0P6dNswbJTUH9EGxkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1041,8 +856,6 @@
     },
     "node_modules/@parcel/compressor-raw": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.16.4.tgz",
-      "integrity": "sha512-IK8IpNhw61B2HKgA1JhGhO9y+ZJFRZNTEmvhN1NdLdPqvgEXm2EunT+m6D9z7xeoeT6XnUKqM0eRckEdD0OXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1059,8 +872,6 @@
     },
     "node_modules/@parcel/config-default": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.16.4.tgz",
-      "integrity": "sha512-kBxuTY/5trEVnvXk92l7LVkYjNuz3SaqWymFhPjEnc8GY4ZVdcWrWdXWTB9hUhpmRYJctFCyGvM0nN05JTiM2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1107,8 +918,6 @@
     },
     "node_modules/@parcel/core": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.16.4.tgz",
-      "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1148,8 +957,6 @@
     },
     "node_modules/@parcel/diagnostic": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.16.4.tgz",
-      "integrity": "sha512-YN5CfX7lFd6yRLxyZT4Sj3sR6t7nnve4TdXSIqapXzQwL7Bw+sj79D95wTq2rCm3mzk5SofGxFAXul2/nG6gcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1166,8 +973,6 @@
     },
     "node_modules/@parcel/error-overlay": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/error-overlay/-/error-overlay-2.16.4.tgz",
-      "integrity": "sha512-e8KYKnMsfmQnqIhsUWBUZAXlDK30wkxsAGle1tZ0gOdoplaIdVq/WjGPatHLf6igLM76c3tRn2vw8jZFput0jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1180,8 +985,6 @@
     },
     "node_modules/@parcel/events": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.16.4.tgz",
-      "integrity": "sha512-slWQkBRAA7o0cN0BLEd+yCckPmlVRVhBZn5Pn6ktm4EzEtrqoMzMeJOxxH8TXaRzrQDYnTcnYIHFgXWd4kkUfg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1194,8 +997,6 @@
     },
     "node_modules/@parcel/feature-flags": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.16.4.tgz",
-      "integrity": "sha512-nYdx53siKPLYikHHxfzgjzzgxdrjquK6DMnuSgOTyIdRG4VHdEN0+NqKijRLuVgiUFo/dtxc2h+amwqFENMw8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1208,8 +1009,6 @@
     },
     "node_modules/@parcel/fs": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.16.4.tgz",
-      "integrity": "sha512-maCMOiVn7oJYZlqlfxgLne8n6tSktIT1k0AeyBp4UGWCXyeJUJ+nL7QYShFpKNLtMLeF0cEtgwRAknWzbcDS1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1233,8 +1032,6 @@
     },
     "node_modules/@parcel/graph": {
       "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.6.4.tgz",
-      "integrity": "sha512-Cj9yV+/k88kFhE+D+gz0YuNRpvNOCVDskO9pFqkcQhGbsGq6kg2XpZ9V7HlYraih31xf8Vb589bZOwjKIiHixQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1251,8 +1048,6 @@
     },
     "node_modules/@parcel/logger": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.16.4.tgz",
-      "integrity": "sha512-QR8QLlKo7xAy9JBpPDAh0RvluaixqPCeyY7Fvo2K7hrU3r85vBNNi06pHiPbWoDmB4x1+QoFwMaGnJOHR+/fMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1269,8 +1064,6 @@
     },
     "node_modules/@parcel/markdown-ansi": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.16.4.tgz",
-      "integrity": "sha512-0+oQApAVF3wMcQ6d1ZfZ0JsRzaMUYj9e4U+naj6YEsFsFGOPp+pQYKXBf1bobQeeB7cPKPT3SUHxFqced722Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1286,8 +1079,6 @@
     },
     "node_modules/@parcel/namer-default": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.16.4.tgz",
-      "integrity": "sha512-CE+0lFg881sJq575EXxj2lKUn81tsS5itpNUUErHxit195m3PExyAhoXM6ed/SXxwi+uv+T5FS/jjDLBNuUFDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1306,8 +1097,6 @@
     },
     "node_modules/@parcel/node-resolver-core": {
       "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.7.4.tgz",
-      "integrity": "sha512-b3VDG+um6IWW5CTod6M9hQsTX5mdIelKmam7mzxzgqg4j5hnycgTWqPMc9UxhYoUY/Q/PHfWepccNcKtvP5JiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1329,8 +1118,6 @@
     },
     "node_modules/@parcel/optimizer-css": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.16.4.tgz",
-      "integrity": "sha512-aqdXCtmvpcXYgJFGk2DtXF34wuM2TD1fZorKMrJdKB9sSkWVRs1tq6RAXQrbi0ZPDH9wfE/9An3YdkTex7RHuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1353,8 +1140,6 @@
     },
     "node_modules/@parcel/optimizer-html": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-html/-/optimizer-html-2.16.4.tgz",
-      "integrity": "sha512-vg/R2uuSni+NYYUUV8m+5bz8p5zBv8wc/nNleoBnGuCDwn7uaUwTZ8Gt9CjZO8jjG0xCLILoc/TW+e2FF3pfgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1373,8 +1158,6 @@
     },
     "node_modules/@parcel/optimizer-image": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.16.4.tgz",
-      "integrity": "sha512-2RV54WnvMYr18lxSx7Zlx/DXpJwMzOiPxDnoFyvaUoYutvgHO6chtcgFgh1Bvw/PoI95vYzlTkZ8QfUOk5A0JA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1398,8 +1181,6 @@
     },
     "node_modules/@parcel/optimizer-svg": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svg/-/optimizer-svg-2.16.4.tgz",
-      "integrity": "sha512-22+BqIffCrVErg8y2XwhasbTaFNn75OKXZ3KTDBIfOSAZKLUKs1iHfDXETzTRN7cVcS+Q36/6EHd7N/RA8i1fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1418,8 +1199,6 @@
     },
     "node_modules/@parcel/optimizer-swc": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.16.4.tgz",
-      "integrity": "sha512-+URqwnB6u1gqaLbG1O1DDApH+UVj4WCbK9No1fdxLBxQ9a84jyli25o1kK1hYB9Nb/JMyYNnEBfvYUW6RphOxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1441,8 +1220,6 @@
     },
     "node_modules/@parcel/package-manager": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.16.4.tgz",
-      "integrity": "sha512-obWv9gZgdnkT3Kd+fBkKjhdNEY7zfOP5gVaox5i4nQstVCaVnDlMv5FwLEXwehL+WbwEcGyEGGxOHHkAFKk7Cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1469,8 +1246,6 @@
     },
     "node_modules/@parcel/packager-css": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.16.4.tgz",
-      "integrity": "sha512-rWRtfiX+VVIOZvq64jpeNUKkvWAbnokfHQsk/js1s5jD4ViNQgPcNLiRaiIANjymqL6+dQqWvGUSW2a5FAZYfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1492,8 +1267,6 @@
     },
     "node_modules/@parcel/packager-html": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.16.4.tgz",
-      "integrity": "sha512-AWo5f6SSqBsg2uWOsX0gPX8hCx2iE6GYLg2Z4/cDy2mPlwDICN8/bxItEztSZFmObi+ti26eetBKRDxAUivyIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1513,8 +1286,6 @@
     },
     "node_modules/@parcel/packager-js": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.16.4.tgz",
-      "integrity": "sha512-L2o39f/fhta+hxto7w8OTUKdstY+te5BmHZREckbQm0KTBg93BG7jB0bfoxLSZF0d8uuAYIVXjzeHNqha+du1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1538,8 +1309,6 @@
     },
     "node_modules/@parcel/packager-js/node_modules/globals": {
       "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1554,8 +1323,6 @@
     },
     "node_modules/@parcel/packager-raw": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.16.4.tgz",
-      "integrity": "sha512-A9j60G9OmbTkEeE4WRMXCiErEprHLs9NkUlC4HXCxmSrPMOVaMaMva2LdejE3A9kujZqYtYfuc8+a+jN+Nro4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1572,8 +1339,6 @@
     },
     "node_modules/@parcel/packager-svg": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.16.4.tgz",
-      "integrity": "sha512-LT9l7eInFrAZJ6w3mYzAUgDq3SIzYbbQyW46Dz26M9lJQbf6uCaATUTac3BEHegW0ikDuw4OOGHK41BVqeeusg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1593,8 +1358,6 @@
     },
     "node_modules/@parcel/packager-ts": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.16.4.tgz",
-      "integrity": "sha512-VjHX/8GFPir+BUyGapgs/8uqymddx5KWt/Fmd2ozyAcRC6rGY7oYAiAPTrTen37KWMSrfZYuNOubZcVWiMAqQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1611,8 +1374,6 @@
     },
     "node_modules/@parcel/packager-wasm": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.16.4.tgz",
-      "integrity": "sha512-AY96Aqu/RpmaSZK2RGkIrZWjAperDw8DAlxLAiaP1D/RPVnikZtl5BmcUt/Wz3PrzG7/q9ZVqqKkWsLmhkjXZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1629,8 +1390,6 @@
     },
     "node_modules/@parcel/plugin": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.16.4.tgz",
-      "integrity": "sha512-aN2VQoRGC1eB41ZCDbPR/Sp0yKOxe31oemzPx1nJzOuebK2Q6FxSrJ9Bjj9j/YCaLzDtPwelsuLOazzVpXJ6qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1646,8 +1405,6 @@
     },
     "node_modules/@parcel/profiler": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.16.4.tgz",
-      "integrity": "sha512-R3JhfcnoReTv2sVFHPR2xKZvs3d3IRrBl9sWmAftbIJFwT4rU70/W7IdwfaJVkD/6PzHq9mcgOh1WKL4KAxPdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1666,8 +1423,6 @@
     },
     "node_modules/@parcel/reporter-cli": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.16.4.tgz",
-      "integrity": "sha512-DQx9TwcTZrDv828+tcwEi//xyW7OHTGzGX1+UEVxPp0mSzuOmDn0zfER8qNIqGr1i4D/FXhb5UJQDhGHV8mOpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1688,8 +1443,6 @@
     },
     "node_modules/@parcel/reporter-dev-server": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.16.4.tgz",
-      "integrity": "sha512-YWvay25htQDifpDRJ0+yFh6xUxKnbfeJxYkPYyuXdxpEUhq4T0UWW0PbPCN/wFX7StgeUTXq5Poeo/+eys9m3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1709,8 +1462,6 @@
     },
     "node_modules/@parcel/reporter-tracer": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.16.4.tgz",
-      "integrity": "sha512-JKnlXpPepak0/ZybmZn9JtyjJiDBWYrt7ZUlXQhQb0xzNcd/k+RqfwVkTKIwyFHsWtym0cwibkvsi2bWFzS7tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1730,8 +1481,6 @@
     },
     "node_modules/@parcel/resolver-default": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.16.4.tgz",
-      "integrity": "sha512-wJe9XQS0hn/t32pntQpJbls3ZL8mGVVhK9L7s7BTmZT9ufnvP2nif1psJz/nbgnP9LF6mLSk43OdMJKpoStsjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1749,8 +1498,6 @@
     },
     "node_modules/@parcel/runtime-browser-hmr": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.16.4.tgz",
-      "integrity": "sha512-asx7p3NjUSfibI3bC7+8+jUIGHWVk2Zuq9SjJGCGDt+auT9A4uSGljnsk1BWWPqqZ0WILubq4czSAqm0+wt4cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1768,8 +1515,6 @@
     },
     "node_modules/@parcel/runtime-js": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.16.4.tgz",
-      "integrity": "sha512-gUKmsjg+PULQBu2QbX0QKll9tXSqHPO8NrfxHwWb2lz5xDKDos1oV0I7BoMWbHhUHkoToXZrm654oGViujtVUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1789,8 +1534,6 @@
     },
     "node_modules/@parcel/runtime-rsc": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-rsc/-/runtime-rsc-2.16.4.tgz",
-      "integrity": "sha512-CHkotYE/cNiUjJmrc5FD9YhlFp1UF5wMNNJmoWaL40eBzsqcaV0sSn5V3bNapwewn3wrMYgdPgvOTHfaZaG73A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1810,8 +1553,6 @@
     },
     "node_modules/@parcel/runtime-service-worker": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.16.4.tgz",
-      "integrity": "sha512-FT0Q58bf5Re+dq5cL2XHbxqHHFZco6qtRijeVpT3TSPMRPlniMArypSytTeZzVNL7h/hxjWsNu7fRuC0yLB5hA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1830,8 +1571,6 @@
     },
     "node_modules/@parcel/rust": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.16.4.tgz",
-      "integrity": "sha512-RBMKt9rCdv6jr4vXG6LmHtxzO5TuhQvXo1kSoSIF7fURRZ81D1jzBtLxwLmfxCPsofJNqWwdhy5vIvisX+TLlQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1862,8 +1601,6 @@
     },
     "node_modules/@parcel/rust-darwin-arm64": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.4.tgz",
-      "integrity": "sha512-P3Se36H9EO1fOlwXqQNQ+RsVKTGn5ztRSUGbLcT8ba6oOMmU1w7J4R810GgsCbwCuF10TJNUMkuD3Q2Sz15Q3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1872,153 +1609,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/rust-darwin-x64": {
-      "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.4.tgz",
-      "integrity": "sha512-8aNKNyPIx3EthYpmVJevIdHmFsOApXAEYGi3HU69jTxLgSIfyEHDdGE9lEsMvhSrd/SSo4/euAtiV+pqK04wnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/rust-linux-arm-gnueabihf": {
-      "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.4.tgz",
-      "integrity": "sha512-QrvqiSHaWRLc0JBHgUHVvDthfWSkA6AFN+ikV1UGENv4j2r/QgvuwJiG0VHrsL6pH5dRqj0vvngHzEgguke9DA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/rust-linux-arm64-gnu": {
-      "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.4.tgz",
-      "integrity": "sha512-f3gBWQHLHRUajNZi3SMmDQiEx54RoRbXtZYQNuBQy7+NolfFcgb1ik3QhkT7xovuTF/LBmaqP3UFy0PxvR/iwQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/rust-linux-arm64-musl": {
-      "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.4.tgz",
-      "integrity": "sha512-cwml18RNKsBwHyZnrZg4jpecXkWjaY/mCArocWUxkFXjjB97L56QWQM9W86f2/Y3HcFcnIGJwx1SDDKJrV6OIA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/rust-linux-x64-gnu": {
-      "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.4.tgz",
-      "integrity": "sha512-0xIjQaN8hiG0F9R8coPYidHslDIrbfOS/qFy5GJNbGA3S49h61wZRBMQqa7JFW4+2T8R0J9j0SKHhLXpbLXrIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/rust-linux-x64-musl": {
-      "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.4.tgz",
-      "integrity": "sha512-fYn21GIecHK9RoZPKwT9NOwxwl3Gy3RYPR6zvsUi0+hpFo19Ph9EzFXN3lT8Pi5KiwQMCU4rsLb5HoWOBM1FeA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/rust-win32-x64-msvc": {
-      "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.4.tgz",
-      "integrity": "sha512-TcpWC3I1mJpfP2++018lgvM7UX0P8IrzNxceBTHUKEIDMwmAYrUKAQFiaU0j1Ldqk6yP8SPZD3cvphumsYpJOQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -2041,8 +1631,6 @@
     },
     "node_modules/@parcel/transformer-babel": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.16.4.tgz",
-      "integrity": "sha512-CMDUOQYX7+cmeyHxHSFnoPcwvXNL7rRFE+Q06uVFzsYYiVhbwGF/1J5Bx4cW3Froumqla4YTytTsEteJEybkdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2066,8 +1654,6 @@
     },
     "node_modules/@parcel/transformer-css": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.16.4.tgz",
-      "integrity": "sha512-VG/+DbDci2HKe20GFRDs65ZQf5GUFfnmZAa1BhVl/MO+ijT3XC3eoVUy5cExRkq4VLcPY4ytL0g/1T2D6x7lBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2090,8 +1676,6 @@
     },
     "node_modules/@parcel/transformer-html": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.16.4.tgz",
-      "integrity": "sha512-w6JErYTeNS+KAzUAER18NHFIFFvxiLGd4Fht1UYcb/FDjJdLAMB/FljyEs0Rto/WAhZ2D0MuSL25HQh837R62g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2110,8 +1694,6 @@
     },
     "node_modules/@parcel/transformer-image": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.16.4.tgz",
-      "integrity": "sha512-ZzIn3KvvRqMfcect4Dy+57C9XoQXZhpVJKBdQWMp9wM1qJEgsVgGDcaSBYCs/UYSKMRMP6Wm20pKCt408RkQzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2130,8 +1712,6 @@
     },
     "node_modules/@parcel/transformer-js": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.16.4.tgz",
-      "integrity": "sha512-FD2fdO6URwAGBPidb3x1dDgLBt972mko0LelcSU05aC/pcKaV9mbCtINbPul1MlStzkxDelhuImcCYIyerheVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2161,8 +1741,6 @@
     },
     "node_modules/@parcel/transformer-json": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.16.4.tgz",
-      "integrity": "sha512-pB3ZNqgokdkBCJ+4G0BrPYcIkyM9K1HVk0GvjzcLEFDKsoAp8BGEM68FzagFM/nVq9anYTshIaoh349GK0M/bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2180,8 +1758,6 @@
     },
     "node_modules/@parcel/transformer-node": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-node/-/transformer-node-2.16.4.tgz",
-      "integrity": "sha512-7t43CPGfMJk1LqFokwxHSsRi+kKC2QvDXaMtqiMShmk50LCwn81WgzuFvNhMwf6lSiBihWupGwF3Fqksg+aisg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2198,8 +1774,6 @@
     },
     "node_modules/@parcel/transformer-postcss": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.16.4.tgz",
-      "integrity": "sha512-jfmh9ho03H+qwz9S1b/a/oaOmgfMovtHKYDweIGMjKULKIee3AFRqo8RZIOuUMjDuqHWK8SqQmjery4syFV3Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2223,8 +1797,6 @@
     },
     "node_modules/@parcel/transformer-posthtml": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.16.4.tgz",
-      "integrity": "sha512-+GXsmGx1L25KQGQnwclgEuQe1t4QU+IoDkgN+Ikj+EnQCOWG4/ts2VpMBeqP5F18ZT4cCSRafj6317o/2lSGJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2242,8 +1814,6 @@
     },
     "node_modules/@parcel/transformer-raw": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.16.4.tgz",
-      "integrity": "sha512-7WDUPq+bW11G9jKxaQIVL+NPGolV99oq/GXhpjYip0SaGaLzRCW7gEk60cftuk0O7MsDaX5jcAJm3G/AX+LJKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2260,8 +1830,6 @@
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.16.4.tgz",
-      "integrity": "sha512-MiLNZrsGQJTANKKa4lzZyUbGj/en0Hms474mMdQkCBFg6GmjfmXwaMMgtTfPA3ZwSp2+3LeObCyca/f9B2gBZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2281,8 +1849,6 @@
     },
     "node_modules/@parcel/transformer-svg": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.16.4.tgz",
-      "integrity": "sha512-0dm4cQr/WpfQP6N0xjFtwdLTxcONDfoLgTOMk4eNUWydHipSgmLtvUk/nOc/FWkwztRScfAObtZXOiPOd3Oy9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2301,8 +1867,6 @@
     },
     "node_modules/@parcel/transformer-typescript-tsc": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-tsc/-/transformer-typescript-tsc-2.16.4.tgz",
-      "integrity": "sha512-zi/Z6jWrrcAm1JkR3660MgMyis0A4GOSdfWhzmO9Ljf3UpWnQ+JgDkkLgdeXXuCJPmwyHLnZIbg7avcJyPCRZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2324,8 +1888,6 @@
     },
     "node_modules/@parcel/transformer-typescript-types": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.16.4.tgz",
-      "integrity": "sha512-Cec1U3iqt7Dsqa17W8PXhfiqn+qlJntwp62Sq2z4S/ud1dkXZuURWeCkLGb5dB/DgNi3Xp0IeQxlSNoKNd/WJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2350,8 +1912,6 @@
     },
     "node_modules/@parcel/ts-utils": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.16.4.tgz",
-      "integrity": "sha512-hOYaQvtyq72jKqBjhtSBVn8vATZuaLnvauVRSDPH1DFOgQaPnM1r71Gw5djx6KMk+Tcpa5NyHNJmLVlVAIQ2tA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2370,8 +1930,6 @@
     },
     "node_modules/@parcel/types": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.16.4.tgz",
-      "integrity": "sha512-ctx4mBskZHXeDVHg4OjMwx18jfYH9BzI/7yqbDQVGvd5lyA+/oVVzYdpele2J2i2sSaJ87cA8nb57GDQ8kHAqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2381,8 +1939,6 @@
     },
     "node_modules/@parcel/types-internal": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.16.4.tgz",
-      "integrity": "sha512-PE6Qmt5cjzBxX+6MPLiF7r+twoC+V9Skt3zyuBQ+H1c0i9o07Bbz2NKX10nvlPukfmW6Fu/1RvTLkzBZR1bU6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2394,8 +1950,6 @@
     },
     "node_modules/@parcel/utils": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.16.4.tgz",
-      "integrity": "sha512-lkmxQHcHyOWZLbV8t+h2CGZIkPiBurLm/TS5wNT7+tq0qt9KbVwL7FP2K93TbXhLMGTmpI79Bf3qKniPM167Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2418,8 +1972,6 @@
     },
     "node_modules/@parcel/validator-typescript": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/validator-typescript/-/validator-typescript-2.16.4.tgz",
-      "integrity": "sha512-hLotPlMXFnWzGstk7rNe6czoEb2wjCNgOjkOMCfUpGWXNk8ZG8cQ6ObvpOjOD+hpKsr1LFc6iCyGZ5F2S9eFBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2443,8 +1995,6 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2477,31 +2027,8 @@
         "@parcel/watcher-win32-x64": "2.5.6"
       }
     },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
       "cpu": [
         "arm64"
       ],
@@ -2510,237 +2037,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10.0.0"
@@ -2752,8 +2048,6 @@
     },
     "node_modules/@parcel/watcher/node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2762,8 +2056,6 @@
     },
     "node_modules/@parcel/workers": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.16.4.tgz",
-      "integrity": "sha512-dkBEWqnHXDZnRbTZouNt4uEGIslJT+V0c8OH1MPOfjISp1ucD6/u9ET8k9d/PxS9h1hL53og0SpBuuSEPLDl6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2809,6 +2101,10 @@
     },
     "node_modules/@pipecat-ai/gemini-live-websocket-transport": {
       "resolved": "transports/gemini-live-websocket-transport",
+      "link": true
+    },
+    "node_modules/@pipecat-ai/livekit-transport": {
+      "resolved": "transports/livekit-transport",
       "link": true
     },
     "node_modules/@pipecat-ai/moq-transport": {
@@ -2872,27 +2168,8 @@
         "@protobuf-ts/runtime": "^2.11.1"
       }
     },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.0.0",
       "cpu": [
         "arm64"
       ],
@@ -2901,308 +2178,95 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "version": "1.0.0",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "8.55.0",
+      "version": "8.55.1",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.55.0"
+        "@sentry/core": "8.55.1"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "8.55.0",
+      "version": "8.55.1",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.55.0"
+        "@sentry/core": "8.55.1"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "8.55.0",
+      "version": "8.55.1",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.55.0",
-        "@sentry/core": "8.55.0"
+        "@sentry-internal/browser-utils": "8.55.1",
+        "@sentry/core": "8.55.1"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "8.55.0",
+      "version": "8.55.1",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "8.55.0",
-        "@sentry/core": "8.55.0"
+        "@sentry-internal/replay": "8.55.1",
+        "@sentry/core": "8.55.1"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "8.55.0",
+      "version": "8.55.1",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.55.0",
-        "@sentry-internal/feedback": "8.55.0",
-        "@sentry-internal/replay": "8.55.0",
-        "@sentry-internal/replay-canvas": "8.55.0",
-        "@sentry/core": "8.55.0"
+        "@sentry-internal/browser-utils": "8.55.1",
+        "@sentry-internal/feedback": "8.55.1",
+        "@sentry-internal/replay": "8.55.1",
+        "@sentry-internal/replay-canvas": "8.55.1",
+        "@sentry/core": "8.55.1"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "8.55.0",
+      "version": "8.55.1",
       "license": "MIT",
       "engines": {
         "node": ">=14.18"
       }
     },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/@simple-libs/stream-utils": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
-      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3214,27 +2278,25 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@svta/cml-iso-bmff": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@svta/cml-iso-bmff/-/cml-iso-bmff-1.0.2.tgz",
-      "integrity": "sha512-c9UgY1z16zgvTEa6fS++9E9zxLuPtLJ4Dw5ebOgEDtwIw+PIhbh3URGXjv30tyDU2QQTXstI6U1q6h/Q4SkxGQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@svta/cml-iso-bmff/-/cml-iso-bmff-1.0.3.tgz",
+      "integrity": "sha512-4vpK8YsxIwUMQZVXjItIcWfM1ekbjjZYBWSiHtA1e/lxSwxkMD65ocil92RCDrVnbsHQNq7SJRkgkIJs2txTDQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@svta/cml-utils": "1.5.0"
+        "@svta/cml-utils": "1.5.1"
       }
     },
     "node_modules/@svta/cml-utils": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@svta/cml-utils/-/cml-utils-1.5.0.tgz",
-      "integrity": "sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@svta/cml-utils/-/cml-utils-1.5.1.tgz",
+      "integrity": "sha512-iQ9OaOZqLPjNCyzo6jZrCyXKtfm9xv389Bbqs6ndWNid59G2vR+Bs2zPBG8iQDyRJWJjO5i2w0A9AS/ZpxctUA==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -3242,15 +2304,13 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.18.tgz",
-      "integrity": "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA==",
+      "version": "1.15.30",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.25"
+        "@swc/types": "^0.1.26"
       },
       "engines": {
         "node": ">=10"
@@ -3260,16 +2320,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.18",
-        "@swc/core-darwin-x64": "1.15.18",
-        "@swc/core-linux-arm-gnueabihf": "1.15.18",
-        "@swc/core-linux-arm64-gnu": "1.15.18",
-        "@swc/core-linux-arm64-musl": "1.15.18",
-        "@swc/core-linux-x64-gnu": "1.15.18",
-        "@swc/core-linux-x64-musl": "1.15.18",
-        "@swc/core-win32-arm64-msvc": "1.15.18",
-        "@swc/core-win32-ia32-msvc": "1.15.18",
-        "@swc/core-win32-x64-msvc": "1.15.18"
+        "@swc/core-darwin-arm64": "1.15.30",
+        "@swc/core-darwin-x64": "1.15.30",
+        "@swc/core-linux-arm-gnueabihf": "1.15.30",
+        "@swc/core-linux-arm64-gnu": "1.15.30",
+        "@swc/core-linux-arm64-musl": "1.15.30",
+        "@swc/core-linux-ppc64-gnu": "1.15.30",
+        "@swc/core-linux-s390x-gnu": "1.15.30",
+        "@swc/core-linux-x64-gnu": "1.15.30",
+        "@swc/core-linux-x64-musl": "1.15.30",
+        "@swc/core-win32-arm64-msvc": "1.15.30",
+        "@swc/core-win32-ia32-msvc": "1.15.30",
+        "@swc/core-win32-x64-msvc": "1.15.30"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -3281,9 +2343,7 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.18.tgz",
-      "integrity": "sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ==",
+      "version": "1.15.30",
       "cpu": [
         "arm64"
       ],
@@ -3292,159 +2352,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.18.tgz",
-      "integrity": "sha512-wZle0eaQhnzxWX5V/2kEOI6Z9vl/lTFEC6V4EWcn+5pDjhemCpQv9e/TDJ0GIoiClX8EDWRvuZwh+Z3dhL1NAg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.18.tgz",
-      "integrity": "sha512-ao61HGXVqrJFHAcPtF4/DegmwEkVCo4HApnotLU8ognfmU8x589z7+tcf3hU+qBiU1WOXV5fQX6W9Nzs6hjxDw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.18.tgz",
-      "integrity": "sha512-3xnctOBLIq3kj8PxOCgPrGjBLP/kNOddr6f5gukYt/1IZxsITQaU9TDyjeX6jG+FiCIHjCuWuffsyQDL5Ew1bg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.18.tgz",
-      "integrity": "sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.18.tgz",
-      "integrity": "sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.18.tgz",
-      "integrity": "sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.18.tgz",
-      "integrity": "sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.18.tgz",
-      "integrity": "sha512-yVuTrZ0RccD5+PEkpcLOBAuPbYBXS6rslENvIXfvJGXSdX5QGi1ehC4BjAMl5FkKLiam4kJECUI0l7Hq7T1vwg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.18.tgz",
-      "integrity": "sha512-7NRmE4hmUQNCbYU3Hn9Tz57mK9Qq4c97ZS+YlamlK6qG9Fb5g/BB3gPDe0iLlJkns/sYv2VWSkm8c3NmbEGjbg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -3452,13 +2359,11 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.17",
+      "version": "0.5.21",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3466,30 +2371,15 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
-      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+      "version": "0.1.26",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3499,10 +2389,13 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3515,35 +2408,29 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.20",
+      "version": "4.17.24",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.16.5",
+      "version": "25.6.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
-      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3551,10 +2438,10 @@
       }
     },
     "node_modules/@typescript/vfs": {
-      "version": "1.6.1",
+      "version": "1.6.4",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.1"
+        "debug": "^4.4.3"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -3567,16 +2454,14 @@
       "license": "ISC"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3585,13 +2470,11 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3612,9 +2495,7 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3625,13 +2506,11 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3639,14 +2518,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3655,9 +2532,7 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.6",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3665,13 +2540,11 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -3680,7 +2553,7 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
+      "version": "8.16.0",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3699,20 +2572,26 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "8.20.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -3736,15 +2615,11 @@
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3767,8 +2642,6 @@
     },
     "node_modules/base-x": {
       "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3776,9 +2649,7 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
-      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+      "version": "2.10.22",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3789,13 +2660,11 @@
       }
     },
     "node_modules/bowser": {
-      "version": "2.11.0",
+      "version": "2.14.1",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3804,9 +2673,7 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
       "dev": true,
       "funding": [
         {
@@ -3824,11 +2691,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3846,9 +2713,7 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001780",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
-      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
+      "version": "1.0.30001790",
       "dev": true,
       "funding": [
         {
@@ -3868,8 +2733,6 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3893,8 +2756,6 @@
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3903,8 +2764,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3916,76 +2775,8 @@
         "node": ">=12"
       }
     },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/clone": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4030,8 +2821,6 @@
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4045,9 +2834,7 @@
       "license": "MIT"
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.2.0.tgz",
-      "integrity": "sha512-4YB1zEXqB17oBI8yRsAs1T+ZhbdsOgJqkl6Trz+GXt/eKf1e4jnA0oW+sOd9BEENzEViuNW0DNoFFjSf3CeC5Q==",
+      "version": "8.3.1",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4058,9 +2845,7 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.2.0.tgz",
-      "integrity": "sha512-fCf+ODjseueTV09wVBoC0HXLi3OyuBJ+HfE3L63Khxqnr99f9nUcnQh3a15lCWHlGLihyZShW/mVVkBagr9JvQ==",
+      "version": "9.3.1",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4071,9 +2856,7 @@
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
-      "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
+      "version": "6.4.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4089,15 +2872,11 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4122,13 +2901,11 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
-      "integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
+      "version": "6.3.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jiti": "^2.6.1"
+        "jiti": "2.6.1"
       },
       "engines": {
         "node": ">=v18"
@@ -4152,21 +2929,8 @@
         "node": ">= 8"
       }
     },
-    "node_modules/dargs": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
-      "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/debug": {
-      "version": "4.4.1",
+      "version": "4.4.3",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4205,8 +2969,6 @@
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4218,8 +2980,6 @@
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4231,8 +2991,6 @@
     },
     "node_modules/dotenv-expand": {
       "version": "11.0.7",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
-      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4246,23 +3004,17 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.344",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/entities": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4274,8 +3026,6 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4284,8 +3034,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4294,8 +3042,6 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4320,8 +3066,6 @@
     },
     "node_modules/eslint": {
       "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
-      "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4423,6 +3167,26 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "dev": true,
@@ -4440,7 +3204,7 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4471,8 +3235,6 @@
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4496,8 +3258,6 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4520,9 +3280,7 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.0",
       "dev": true,
       "funding": [
         {
@@ -4538,8 +3296,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4594,17 +3350,12 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4616,8 +3367,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4633,35 +3382,18 @@
       }
     },
     "node_modules/git-raw-commits": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
-      "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
-      "deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
+      "version": "5.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "dargs": "^8.0.0",
-        "meow": "^12.0.1",
-        "split2": "^4.0.0"
+        "@conventional-changelog/git-client": "^2.6.0",
+        "meow": "^13.0.0"
       },
       "bin": {
-        "git-raw-commits": "cli.mjs"
+        "git-raw-commits": "src/cli.js"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/meow": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=18"
       }
     },
     "node_modules/glob-parent": {
@@ -4676,16 +3408,14 @@
       }
     },
     "node_modules/global-directory": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
-      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "version": "5.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ini": "4.1.1"
+        "ini": "6.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4704,8 +3434,6 @@
     },
     "node_modules/happy-dom": {
       "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
-      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4730,8 +3458,6 @@
     },
     "node_modules/husky": {
       "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4767,10 +3493,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4787,19 +3519,15 @@
       }
     },
     "node_modules/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "version": "6.0.0",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4809,6 +3537,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4824,8 +3560,6 @@
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4834,8 +3568,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4869,36 +3601,27 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.1.1",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4914,13 +3637,11 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
+      "version": "1.0.0",
       "dev": true,
       "license": "MIT"
     },
@@ -4931,8 +3652,6 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4971,8 +3690,6 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -4999,31 +3716,8 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -5032,195 +3726,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -5232,8 +3737,6 @@
     },
     "node_modules/lightningcss/node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5242,15 +3745,31 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/livekit-client": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.21.0.tgz",
+      "integrity": "sha512-RBUhPkV/sl1nzl8lokVlK5uATPwn0AlsudCBZXissw/kDl9yz8ac4pNJ43iPpMVoHOeBYH/BZ3vUC1adqa/zFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.50.4",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "9.0.6"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/lmdb": {
       "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.8.5.tgz",
-      "integrity": "sha512-9bMdFfc80S+vSldBmG3HOuLVHnxRdNTlpzR6QDnzqCQtCzGUEAGTzBKYMeIM+I/sU4oZfgbcbS7X7F65/z/oxQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5275,8 +3794,6 @@
     },
     "node_modules/lmdb/node_modules/node-addon-api": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5296,21 +3813,15 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
       "dev": true,
       "license": "MIT"
     },
@@ -5321,36 +3832,37 @@
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.upperfirst": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5359,8 +3871,6 @@
     },
     "node_modules/meow": {
       "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5372,8 +3882,6 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5385,8 +3893,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5398,9 +3904,7 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
-      "integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
+      "version": "1.11.10",
       "dev": true,
       "license": "MIT",
       "optionalDependencies": {
@@ -5409,8 +3913,6 @@
     },
     "node_modules/msgpackr-extract": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5432,8 +3934,6 @@
     },
     "node_modules/msgpackr-extract/node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -5443,8 +3943,6 @@
     },
     "node_modules/msgpackr-extract/node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
-      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5458,9 +3956,7 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "version": "3.3.12",
       "dev": true,
       "funding": [
         {
@@ -5483,15 +3979,11 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
-      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5505,8 +3997,6 @@
     },
     "node_modules/node-gyp-build-optional-packages/node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5514,9 +4004,7 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.38",
       "dev": true,
       "license": "MIT"
     },
@@ -5527,8 +4015,6 @@
     },
     "node_modules/obug": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -5554,8 +4040,6 @@
     },
     "node_modules/ordered-binary": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.6.1.tgz",
-      "integrity": "sha512-QkCdPooczexPLiXIrbVOPYkR3VO3T6v2OyKRkR1Xbhpy7/LAVXwahnRCgRp78Oe/Ehf0C/HATAxfSr6eA1oX+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5605,8 +4089,6 @@
     },
     "node_modules/parcel": {
       "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.16.4.tgz",
-      "integrity": "sha512-RQlrqs4ujYNJpTQi+dITqPKNhRWEqpjPd1YBcGp50Wy3FcJHpwu0/iRm7XWz2dKU/Bwp2qCcVYPIeEDYi2uOUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5650,8 +4132,6 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5685,8 +4165,6 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5697,8 +4175,6 @@
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5709,9 +4185,7 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.14",
       "dev": true,
       "funding": [
         {
@@ -5729,7 +4203,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5739,8 +4213,6 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5753,7 +4225,7 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
+      "version": "3.8.3",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5776,8 +4248,6 @@
     },
     "node_modules/react-refresh": {
       "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.16.0.tgz",
-      "integrity": "sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5786,15 +4256,11 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5803,8 +4269,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5812,22 +4276,20 @@
       }
     },
     "node_modules/resolve-from": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
-        "@rolldown/pluginutils": "^1.0.0"
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -5836,36 +4298,33 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -5883,8 +4342,21 @@
       ],
       "license": "MIT"
     },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
+    },
     "node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.7.4",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5925,44 +4397,50 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -5988,8 +4466,6 @@
     },
     "node_modules/term-size": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
-      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6001,15 +4477,11 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6017,9 +4489,7 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "version": "0.2.16",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6035,8 +4505,6 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6060,8 +4528,6 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -6079,7 +4545,7 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
+      "version": "5.9.3",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6090,14 +4556,12 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
+      "version": "7.19.2",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -6135,8 +4599,6 @@
     },
     "node_modules/utility-types": {
       "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
-      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6157,17 +4619,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.0.12",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
-        "tinyglobby": "^0.2.17"
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -6235,19 +4695,17 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -6275,12 +4733,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -6326,15 +4784,24 @@
     },
     "node_modules/weak-lru-cache": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
-      "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6357,8 +4824,6 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6380,10 +4845,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.20.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6411,8 +4890,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -6421,8 +4898,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6440,60 +4915,10 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {
@@ -6523,6 +4948,7 @@
         "@pipecat-ai/client-js": "^1.7.0",
         "@pipecat-ai/daily-transport": "*",
         "@pipecat-ai/gemini-live-websocket-transport": "*",
+        "@pipecat-ai/livekit-transport": "*",
         "@pipecat-ai/moq-transport": "*",
         "@pipecat-ai/openai-realtime-webrtc-transport": "*",
         "@pipecat-ai/small-webrtc-transport": "*",
@@ -6567,9 +4993,39 @@
         "@pipecat-ai/client-js": "~1.13.0"
       }
     },
+    "transports/gemini-live-websocket-transport/node_modules/@types/node": {
+      "version": "22.19.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "transports/gemini-live-websocket-transport/node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "transports/livekit-transport": {
+      "name": "@pipecat-ai/livekit-transport",
+      "version": "1.8.1",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "livekit-client": "^2.21.0"
+      },
+      "devDependencies": {
+        "@pipecat-ai/client-js": "^1.13.0",
+        "eslint": "9.39.1",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1"
+      },
+      "peerDependencies": {
+        "@pipecat-ai/client-js": "^1.13.0"
+      }
+    },
     "transports/moq-transport": {
       "name": "@pipecat-ai/moq-transport",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@moq/hang": "^0.2.12",
@@ -6590,6 +5046,23 @@
         "@pipecat-ai/client-js": "~1.13.0"
       }
     },
+    "transports/moq-transport/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "transports/moq-transport/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "transports/openai-realtime-webrtc-transport": {
       "name": "@pipecat-ai/openai-realtime-webrtc-transport",
       "version": "1.5.7",
@@ -6608,6 +5081,19 @@
       "peerDependencies": {
         "@pipecat-ai/client-js": "~1.13.0"
       }
+    },
+    "transports/openai-realtime-webrtc-transport/node_modules/@types/node": {
+      "version": "22.19.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "transports/openai-realtime-webrtc-transport/node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
     },
     "transports/small-webrtc-transport": {
       "name": "@pipecat-ai/small-webrtc-transport",
@@ -6630,6 +5116,19 @@
         "@pipecat-ai/client-js": "~1.13.0"
       }
     },
+    "transports/small-webrtc-transport/node_modules/@types/node": {
+      "version": "22.19.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "transports/small-webrtc-transport/node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "transports/websocket-transport": {
       "name": "@pipecat-ai/websocket-transport",
       "version": "1.7.1",
@@ -6650,6 +5149,19 @@
       "peerDependencies": {
         "@pipecat-ai/client-js": "~1.13.0"
       }
+    },
+    "transports/websocket-transport/node_modules/@types/node": {
+      "version": "22.19.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "transports/websocket-transport/node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5008,7 +5008,7 @@
     },
     "transports/livekit-transport": {
       "name": "@pipecat-ai/livekit-transport",
-      "version": "1.8.1",
+      "version": "1.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "livekit-client": "^2.21.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5020,7 +5020,7 @@
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "^1.13.0"
+        "@pipecat-ai/client-js": "~1.13.0"
       }
     },
     "transports/moq-transport": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,6 +12,7 @@
     "@pipecat-ai/client-js": "^1.7.0",
     "@pipecat-ai/daily-transport": "*",
     "@pipecat-ai/gemini-live-websocket-transport": "*",
+    "@pipecat-ai/livekit-transport": "*",
     "@pipecat-ai/moq-transport": "*",
     "@pipecat-ai/openai-realtime-webrtc-transport": "*",
     "@pipecat-ai/small-webrtc-transport": "*",

--- a/tests/src/transports/livekit.spec.ts
+++ b/tests/src/transports/livekit.spec.ts
@@ -1,0 +1,508 @@
+/**
+ * Characterization tests for LiveKitTransport's lifecycle and connection contract.
+ *
+ * livekit-client's Room drives real WebRTC + device access, none of which is
+ * available (or desirable) under happy-dom. We mock the module with a
+ * controllable fake Room so the tests assert behavior at the abstract Transport
+ * boundary — state transitions, callback wiring, auth handling, device
+ * enumeration, and message framing — exactly as the moq spec does for the
+ * @moq/* stack. Event names/enum values are internal to the mock: the transport
+ * reads them from the same module, so only self-consistency matters.
+ */
+
+import { TransportStartError } from "@pipecat-ai/client-js";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type Mock,
+  test,
+  vi,
+} from "vitest";
+
+// ---- livekit-client mock ---------------------------------------------------
+vi.mock("livekit-client", () => {
+  const RoomEvent = {
+    DataReceived: "dataReceived",
+    TrackSubscribed: "trackSubscribed",
+    TrackUnsubscribed: "trackUnsubscribed",
+    ParticipantConnected: "participantConnected",
+    ParticipantDisconnected: "participantDisconnected",
+    Disconnected: "disconnected",
+    LocalTrackPublished: "localTrackPublished",
+    LocalTrackUnpublished: "localTrackUnpublished",
+    MediaDevicesError: "mediaDevicesError",
+  };
+
+  const Track = {
+    Source: {
+      Microphone: "microphone",
+      Camera: "camera",
+      ScreenShare: "screen_share",
+      ScreenShareAudio: "screen_share_audio",
+    },
+  };
+
+  class LocalParticipant {
+    identity = "local-user";
+    name = "Local User";
+    isScreenShareEnabled = false;
+    setMicrophoneEnabled = vi.fn(async (_e: boolean) => {});
+    setCameraEnabled = vi.fn(async (_e: boolean) => {});
+    setScreenShareEnabled = vi.fn(async (_e: boolean) => {});
+    publishData = vi.fn();
+    waitUntilActive = vi.fn(async () => {});
+    getTrackPublication = vi.fn((_s: string) => undefined as unknown);
+  }
+
+  class RemoteParticipant {}
+
+  class Room {
+    options: unknown;
+    localParticipant = new LocalParticipant();
+    remoteParticipants = new Map<string, unknown>();
+    connect = vi.fn(async (_u: string, _t: string, _o?: unknown) => {});
+    disconnect = vi.fn(async () => {});
+    switchActiveDevice = vi.fn(async (_k: string, _id: string) => {});
+    private _handlers: Record<string, ((...a: unknown[]) => void)[]> = {};
+    constructor(options?: unknown) {
+      this.options = options;
+    }
+    on(event: string, cb: (...a: unknown[]) => void) {
+      (this._handlers[event] ||= []).push(cb);
+      return this;
+    }
+    emit(event: string, ...args: unknown[]) {
+      (this._handlers[event] || []).forEach((h) => h(...args));
+    }
+  }
+
+  return { Room, RoomEvent, Track, LocalParticipant, RemoteParticipant };
+});
+
+import { LiveKitTransport } from "@pipecat-ai/livekit-transport";
+// Values come from the mock above; only self-consistency with the source matters.
+import { RoomEvent, Track } from "livekit-client";
+
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+// ---- navigator.mediaDevices stub -------------------------------------------
+const DEFAULT_DEVICES = [
+  { kind: "audioinput", deviceId: "mic-1", label: "Mic 1", groupId: "g1" },
+  { kind: "audioinput", deviceId: "mic-2", label: "Mic 2", groupId: "g1" },
+  { kind: "videoinput", deviceId: "cam-1", label: "Cam 1", groupId: "g2" },
+  { kind: "audiooutput", deviceId: "spk-1", label: "Speaker 1", groupId: "g3" },
+] as MediaDeviceInfo[];
+
+interface MediaDevicesStub {
+  enumerateDevices: Mock;
+  addEventListener: Mock;
+  removeEventListener: Mock;
+  getUserMedia: Mock;
+}
+
+function stubMediaDevices(
+  devices: MediaDeviceInfo[] = DEFAULT_DEVICES
+): MediaDevicesStub {
+  const stub: MediaDevicesStub = {
+    enumerateDevices: vi.fn(async () => devices),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    getUserMedia: vi.fn(
+      async () => ({ getTracks: () => [] }) as unknown as MediaStream
+    ),
+  };
+  Object.defineProperty(globalThis.navigator, "mediaDevices", {
+    configurable: true,
+    value: stub,
+  });
+  return stub;
+}
+
+// ---- internal fake-room accessor -------------------------------------------
+interface FakeRoom {
+  localParticipant: {
+    isScreenShareEnabled: boolean;
+    setMicrophoneEnabled: Mock;
+    setCameraEnabled: Mock;
+    setScreenShareEnabled: Mock;
+    publishData: Mock;
+    waitUntilActive: Mock;
+    getTrackPublication: Mock;
+  };
+  remoteParticipants: Map<string, unknown>;
+  connect: Mock;
+  disconnect: Mock;
+  switchActiveDevice: Mock;
+  emit: (event: string, ...args: unknown[]) => void;
+}
+
+const roomOf = (t: LiveKitTransport): FakeRoom =>
+  (t as unknown as { _room: FakeRoom })._room;
+
+// _connect / _validateConnectionParams take the non-exported LiveKitConnectParams;
+// cast loose test objects through this helper to stay readable.
+const connect = (t: LiveKitTransport, params: Record<string, unknown>) =>
+  t._connect(params as never);
+
+describe("LiveKitTransport — characterization", () => {
+  let transport: LiveKitTransport;
+  let mediaDevices: MediaDevicesStub;
+
+  beforeEach(() => {
+    mediaDevices = stubMediaDevices();
+    transport = new LiveKitTransport();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("lifecycle", () => {
+    test("initial state after construction is 'disconnected'", () => {
+      expect(transport.state).toBe("disconnected");
+    });
+
+    test("initialize() keeps state 'disconnected' and records no transitions", () => {
+      // initialize() re-sets the same 'disconnected' sentinel the abstract
+      // Transport already holds, so the state setter short-circuits and never
+      // fires onTransportStateChanged.
+      const { callbacks, recorder } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      expect(transport.state).toBe("disconnected");
+      expect(recorder.states).toEqual([]);
+    });
+
+    test.each([
+      [{ enableMic: true, enableCam: false }],
+      [{ enableMic: false, enableCam: false }],
+      [{ enableMic: true, enableCam: true }],
+      [{ enableMic: false, enableCam: true }],
+    ])(
+      "initialize(%j) stores enable flags on isMicEnabled/isCamEnabled",
+      (opts) => {
+        const { callbacks } = buildSpyCallbacks();
+        wireTransport(transport, callbacks, opts);
+
+        expect(transport.isMicEnabled).toBe(opts.enableMic);
+        expect(transport.isCamEnabled).toBe(opts.enableCam);
+      }
+    );
+
+    test("initialize() attaches a devicechange listener", () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      expect(mediaDevices.addEventListener).toHaveBeenCalledWith(
+        "devicechange",
+        expect.any(Function)
+      );
+    });
+
+    test("initDevices(): disconnected → initializing → initialized and enumerates devices", async () => {
+      const { callbacks, recorder, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      await transport.initDevices();
+
+      expect(transport.state).toBe("initialized");
+      expect(recorder.states).toEqual(["initializing", "initialized"]);
+      expect(mediaDevices.enumerateDevices).toHaveBeenCalled();
+      expect(spies.onAvailableMicsUpdated).toHaveBeenLastCalledWith(
+        expect.objectContaining({ length: 2 })
+      );
+      expect(spies.onAvailableCamsUpdated).toHaveBeenLastCalledWith(
+        expect.objectContaining({ length: 1 })
+      );
+      expect(spies.onAvailableSpeakersUpdated).toHaveBeenLastCalledWith(
+        expect.objectContaining({ length: 1 })
+      );
+    });
+
+    test("sendReadyMessage() flips to 'ready', waits for the participant, then publishes client-ready", async () => {
+      const { callbacks, recorder } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      recorder.states.length = 0;
+
+      await transport.sendReadyMessage();
+
+      expect(transport.state).toBe("ready");
+      expect(recorder.states).toEqual(["ready"]);
+      expect(roomOf(transport).localParticipant.waitUntilActive).toHaveBeenCalledTimes(1);
+      expect(roomOf(transport).localParticipant.publishData).toHaveBeenCalledWith(
+        expect.any(Uint8Array),
+        { reliable: true }
+      );
+    });
+
+    test("_disconnect(): disconnecting → disconnected, disconnects room, removes listener, fires onDisconnected", async () => {
+      const { callbacks, recorder, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      recorder.states.length = 0;
+
+      await transport._disconnect();
+
+      expect(transport.state).toBe("disconnected");
+      expect(recorder.states).toEqual(["disconnecting", "disconnected"]);
+      expect(roomOf(transport).disconnect).toHaveBeenCalledTimes(1);
+      expect(mediaDevices.removeEventListener).toHaveBeenCalledWith(
+        "devicechange",
+        expect.any(Function)
+      );
+      expect(spies.onDisconnected).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("connection", () => {
+    test("_connect() with direct url+token connects and reaches 'connected'", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+
+      expect(roomOf(transport).connect).toHaveBeenCalledWith(
+        "wss://lk.example",
+        "tok",
+        undefined
+      );
+      expect(transport.state).toBe("connected");
+      expect(spies.onConnected).toHaveBeenCalledTimes(1);
+    });
+
+    test("_connect() applies initialize()'s enableMic/enableCam to the local participant", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: true, enableCam: false });
+
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+
+      expect(roomOf(transport).localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(true);
+      expect(roomOf(transport).localParticipant.setCameraEnabled).toHaveBeenCalledWith(false);
+    });
+
+    test("_connect() without url/token/authUrl throws TransportStartError and enters 'error'", async () => {
+      const { callbacks, recorder } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      await expect(connect(transport, {})).rejects.toThrow("Missing url or token");
+      expect(transport.state).toBe("error");
+      expect(recorder.states).toEqual(["connecting", "error"]);
+    });
+
+    test("_connect() with authUrl (GET default) fetches credentials then connects", async () => {
+      const fetchMock = vi.fn(async () => ({
+        json: async () => ({ url: "wss://fetched", token: "fetched-tok" }),
+      }));
+      vi.stubGlobal("fetch", fetchMock);
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      await connect(transport, { authUrl: "https://auth.example/lk" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://auth.example/lk",
+        expect.objectContaining({ method: "GET" })
+      );
+      expect(roomOf(transport).connect).toHaveBeenCalledWith(
+        "wss://fetched",
+        "fetched-tok",
+        undefined
+      );
+      expect(transport.state).toBe("connected");
+    });
+
+    test("_connect() with authUrl POST sends the JSON auth body", async () => {
+      const fetchMock = vi.fn(async () => ({
+        json: async () => ({ url: "wss://fetched", token: "fetched-tok" }),
+      }));
+      vi.stubGlobal("fetch", fetchMock);
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      await connect(transport, {
+        authUrl: "https://auth.example/lk",
+        authMethod: "POST",
+        authBody: { roomName: "room-1" },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://auth.example/lk",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ roomName: "room-1" }),
+        })
+      );
+    });
+
+    test("_connect() surfaces an authUrl fetch failure as TransportStartError + 'error' state", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          throw new Error("network down");
+        })
+      );
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      await expect(
+        connect(transport, { authUrl: "https://auth.example/lk" })
+      ).rejects.toThrow("Failed to fetch credentials");
+      expect(transport.state).toBe("error");
+    });
+
+    test("_connect() surfaces a room.connect() failure as TransportStartError + 'error' state", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      roomOf(transport).connect.mockRejectedValueOnce(new Error("ice failed"));
+
+      await expect(
+        connect(transport, { url: "wss://lk.example", token: "tok" })
+      ).rejects.toBeInstanceOf(TransportStartError);
+      expect(transport.state).toBe("error");
+    });
+  });
+
+  describe("messaging", () => {
+    test("sendMessage() before connect is a no-op (guarded, publishData not called)", () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      expect(() =>
+        transport.sendMessage({
+          id: "x",
+          label: "rtvi-ai",
+          type: "test",
+          data: {},
+        } as never)
+      ).not.toThrow();
+      expect(roomOf(transport).localParticipant.publishData).not.toHaveBeenCalled();
+    });
+
+    test("sendMessage() when connected publishes encoded bytes over the reliable data channel", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+
+      transport.sendMessage({
+        id: "x",
+        label: "rtvi-ai",
+        type: "test",
+        data: {},
+      } as never);
+
+      expect(roomOf(transport).localParticipant.publishData).toHaveBeenCalledWith(
+        expect.any(Uint8Array),
+        { reliable: true }
+      );
+    });
+
+    test("inbound DataReceived is decoded, parsed, and forwarded to the message handler", () => {
+      const { callbacks } = buildSpyCallbacks();
+      const { onMessage } = wireTransport(transport, callbacks);
+
+      const payload = new TextEncoder().encode(
+        JSON.stringify({ id: "1", label: "rtvi-ai", type: "server-message", data: {} })
+      );
+      roomOf(transport).emit(RoomEvent.DataReceived, payload);
+
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "server-message" })
+      );
+    });
+
+    test("inbound DataReceived with invalid JSON is swallowed (no throw, handler not called)", () => {
+      const { callbacks } = buildSpyCallbacks();
+      const { onMessage } = wireTransport(transport, callbacks);
+
+      const payload = new TextEncoder().encode("{ not valid json");
+      expect(() =>
+        roomOf(transport).emit(RoomEvent.DataReceived, payload)
+      ).not.toThrow();
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("device management", () => {
+    test("getAllMics/getAllCams/getAllSpeakers filter enumerated devices by kind", async () => {
+      expect(await transport.getAllMics()).toHaveLength(2);
+      expect(await transport.getAllCams()).toHaveLength(1);
+      expect(await transport.getAllSpeakers()).toHaveLength(1);
+    });
+
+    test("updateMic() switches the active device and fires onMicUpdated", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      await transport.updateMic("mic-2");
+
+      expect(roomOf(transport).switchActiveDevice).toHaveBeenCalledWith(
+        "audioinput",
+        "mic-2"
+      );
+      expect(spies.onMicUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "mic-2" })
+      );
+    });
+
+    test("updateMic() reports a switch failure through onDeviceError", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      roomOf(transport).switchActiveDevice.mockRejectedValueOnce(new Error("boom"));
+
+      await transport.updateMic("mic-2");
+
+      expect(spies.onDeviceError).toHaveBeenCalledTimes(1);
+      expect(spies.onMicUpdated).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("participants & tracks", () => {
+    test("ParticipantConnected maps a remote participant and fires onParticipantJoined", () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      // A plain object is not `instanceof` the mock LocalParticipant, so it is
+      // mapped as a remote (local: false) participant.
+      roomOf(transport).emit(RoomEvent.ParticipantConnected, {
+        identity: "bot-1",
+        name: "Bot",
+      });
+
+      expect(spies.onParticipantJoined).toHaveBeenCalledWith({
+        id: "bot-1",
+        name: "Bot",
+        local: false,
+      });
+    });
+
+    test("tracks() exposes the first remote participant's mic track as the bot audio", () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      const botTrack = {} as MediaStreamTrack;
+      roomOf(transport).remoteParticipants.set("bot-1", {
+        identity: "bot-1",
+        name: "Bot",
+        getTrackPublication: (s: string) =>
+          s === Track.Source.Microphone
+            ? { track: { mediaStreamTrack: botTrack } }
+            : undefined,
+      });
+
+      expect(transport.tracks().bot?.audio).toBe(botTrack);
+    });
+  });
+
+  describe("_validateConnectionParams", () => {
+    test("passes an object through unchanged", () => {
+      const params = { url: "wss://lk.example", token: "tok" };
+      expect(transport._validateConnectionParams(params)).toBe(params);
+    });
+
+    test("returns undefined for null / non-object input", () => {
+      expect(transport._validateConnectionParams(null)).toBeUndefined();
+      expect(transport._validateConnectionParams("nope")).toBeUndefined();
+    });
+  });
+});

--- a/tests/src/transports/livekit.spec.ts
+++ b/tests/src/transports/livekit.spec.ts
@@ -184,8 +184,13 @@ vi.mock("livekit-client", () => {
     connect = vi.fn(async (_u: string, _t: string, _o?: unknown) => {
       this.state = ConnectionState.Connected;
     });
+    // Mirrors livekit-client's real Room.disconnect(): handleDisconnect()
+    // stops/unpublishes tracks and emits RoomEvent.Disconnected synchronously,
+    // all before disconnect()'s own promise resolves — not after.
     disconnect = vi.fn(async () => {
+      if (this.state === ConnectionState.Disconnected) return;
       this.state = ConnectionState.Disconnected;
+      this.emit(RoomEvent.Disconnected);
     });
     switchActiveDevice = vi.fn(async (_k: string, _id: string) => {});
     private _handlers: Record<string, ((...a: unknown[]) => void)[]> = {};
@@ -590,6 +595,23 @@ describe("LiveKitTransport — characterization", () => {
         "devicechange",
         expect.any(Function)
       );
+      expect(spies.onDisconnected).toHaveBeenCalledTimes(1);
+    });
+
+    // Regression: livekit-client's real Room.disconnect() emits
+    // RoomEvent.Disconnected synchronously, before its own promise resolves
+    // — so handleRoomDisconnected() (via that event) used to run the full
+    // teardown once, and then _disconnect()'s own unconditional teardown at
+    // the end ran it a second time, firing onDisconnected twice per
+    // disconnect. Exercise the case where the room actually was connected
+    // (so the event genuinely fires) and confirm it's still exactly once.
+    test("_disconnect() after an actual connection fires onDisconnected exactly once, not twice", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+
+      await transport._disconnect();
+
       expect(spies.onDisconnected).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/src/transports/livekit.spec.ts
+++ b/tests/src/transports/livekit.spec.ts
@@ -603,6 +603,61 @@ describe("LiveKitTransport — characterization", () => {
 
       expect(track.stop).toHaveBeenCalledTimes(1);
     });
+
+    test("_disconnect() reports mic/cam as stopped and flips isMicEnabled/isCamEnabled to false", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: true, enableCam: true });
+      await transport.initDevices();
+      const micTrack = localAudioTrackOf(transport)!;
+      const camTrack = localVideoTrackOf(transport)!;
+
+      await transport._disconnect();
+
+      expect(spies.onTrackStopped).toHaveBeenCalledWith(
+        micTrack.mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+      expect(spies.onTrackStopped).toHaveBeenCalledWith(
+        camTrack.mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+      expect(transport.isMicEnabled).toBe(false);
+      expect(transport.isCamEnabled).toBe(false);
+    });
+
+    test("isMicEnabled/isCamEnabled already reflect false from inside disconnect's onTrackStopped callback", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: true, enableCam: true });
+      await transport.initDevices();
+
+      const seenMic: boolean[] = [];
+      const seenCam: boolean[] = [];
+      const micTrack = localAudioTrackOf(transport)!;
+      const camTrack = localVideoTrackOf(transport)!;
+      spies.onTrackStopped.mockImplementation((track: MediaStreamTrack) => {
+        if (track === micTrack.mediaStreamTrack) seenMic.push(transport.isMicEnabled);
+        if (track === camTrack.mediaStreamTrack) seenCam.push(transport.isCamEnabled);
+      });
+
+      await transport._disconnect();
+
+      expect(seenMic).toEqual([false]);
+      expect(seenCam).toEqual([false]);
+    });
+
+    test("_disconnect() is a no-op for onTrackStopped when nothing was ever live (mic/cam disabled)", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, {
+        enableMic: false,
+        enableCam: false,
+      });
+
+      await transport._disconnect();
+
+      expect(spies.onTrackStopped).not.toHaveBeenCalled();
+      expect(transport.isMicEnabled).toBe(false);
+      expect(transport.isCamEnabled).toBe(false);
+    });
   });
 
   describe("connection", () => {
@@ -870,6 +925,26 @@ describe("LiveKitTransport — characterization", () => {
       expect(track.unmute).toHaveBeenCalledTimes(1);
       // Toggling reuses the existing track; it never re-acquires.
       expect(createLocalAudioTrack).not.toHaveBeenCalled();
+    });
+
+    test("isMicEnabled already reflects the new state from inside the onTrackStopped/onTrackStarted callback", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices();
+
+      const seenDuringStopped: boolean[] = [];
+      spies.onTrackStopped.mockImplementation(() => {
+        seenDuringStopped.push(transport.isMicEnabled);
+      });
+      await transport.enableMic(false);
+      expect(seenDuringStopped).toEqual([false]);
+
+      const seenDuringStarted: boolean[] = [];
+      spies.onTrackStarted.mockImplementation(() => {
+        seenDuringStarted.push(transport.isMicEnabled);
+      });
+      await transport.enableMic(true);
+      expect(seenDuringStarted).toEqual([true]);
     });
 
     test("enableMic(true) with no existing track pre-warms one via createLocalAudioTrack() when not connected", async () => {

--- a/tests/src/transports/livekit.spec.ts
+++ b/tests/src/transports/livekit.spec.ts
@@ -48,15 +48,41 @@ vi.mock("livekit-client", () => {
     identity = "local-user";
     name = "Local User";
     isScreenShareEnabled = false;
+    lastMicrophoneError: Error | undefined = undefined;
+    lastCameraError: Error | undefined = undefined;
     setMicrophoneEnabled = vi.fn(async (_e: boolean) => {});
     setCameraEnabled = vi.fn(async (_e: boolean) => {});
     setScreenShareEnabled = vi.fn(async (_e: boolean) => {});
     publishData = vi.fn();
+    publishTrack = vi.fn(async (_t: unknown) => {});
     waitUntilActive = vi.fn(async () => {});
     getTrackPublication = vi.fn((_s: string) => undefined as unknown);
   }
 
   class RemoteParticipant {}
+
+  // Mirrors livekit-client's MediaDeviceFailure enum + getFailure() classifier
+  // so the transport (which reads both from this same mocked module) stays
+  // self-consistent under test.
+  const MediaDeviceFailure = {
+    PermissionDenied: "PermissionDenied",
+    NotFound: "NotFound",
+    DeviceInUse: "DeviceInUse",
+    Other: "Other",
+    getFailure(error: unknown): string | undefined {
+      if (error && typeof error === "object" && "name" in error) {
+        const name = (error as { name: string }).name;
+        if (name === "NotAllowedError" || name === "PermissionDeniedError")
+          return "PermissionDenied";
+        if (name === "NotFoundError" || name === "DevicesNotFoundError")
+          return "NotFound";
+        if (name === "NotReadableError" || name === "TrackStartError")
+          return "DeviceInUse";
+        return "Other";
+      }
+      return undefined;
+    },
+  };
 
   class Room {
     options: unknown;
@@ -78,7 +104,14 @@ vi.mock("livekit-client", () => {
     }
   }
 
-  return { Room, RoomEvent, Track, LocalParticipant, RemoteParticipant };
+  return {
+    Room,
+    RoomEvent,
+    Track,
+    LocalParticipant,
+    RemoteParticipant,
+    MediaDeviceFailure,
+  };
 });
 
 import { LiveKitTransport } from "@pipecat-ai/livekit-transport";
@@ -124,10 +157,13 @@ function stubMediaDevices(
 interface FakeRoom {
   localParticipant: {
     isScreenShareEnabled: boolean;
+    lastMicrophoneError: Error | undefined;
+    lastCameraError: Error | undefined;
     setMicrophoneEnabled: Mock;
     setCameraEnabled: Mock;
     setScreenShareEnabled: Mock;
     publishData: Mock;
+    publishTrack: Mock;
     waitUntilActive: Mock;
     getTrackPublication: Mock;
   };
@@ -277,78 +313,21 @@ describe("LiveKitTransport — characterization", () => {
 
       await connect(transport, { url: "wss://lk.example", token: "tok" });
 
+      // With no pre-created (initDevices) tracks, an enabled device is turned
+      // on via setXEnabled(true); a disabled one is left untouched.
       expect(roomOf(transport).localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(true);
-      expect(roomOf(transport).localParticipant.setCameraEnabled).toHaveBeenCalledWith(false);
+      expect(roomOf(transport).localParticipant.setCameraEnabled).not.toHaveBeenCalled();
     });
 
-    test("_connect() without url/token/authUrl throws TransportStartError and enters 'error'", async () => {
+    test("_connect() without url/token throws TransportStartError and enters 'error'", async () => {
       const { callbacks, recorder } = buildSpyCallbacks();
       wireTransport(transport, callbacks);
 
-      await expect(connect(transport, {})).rejects.toThrow("Missing url or token");
+      await expect(connect(transport, {})).rejects.toThrow(
+        "LiveKit connection requires 'url' and 'token'"
+      );
       expect(transport.state).toBe("error");
-      expect(recorder.states).toEqual(["connecting", "error"]);
-    });
-
-    test("_connect() with authUrl (GET default) fetches credentials then connects", async () => {
-      const fetchMock = vi.fn(async () => ({
-        json: async () => ({ url: "wss://fetched", token: "fetched-tok" }),
-      }));
-      vi.stubGlobal("fetch", fetchMock);
-      const { callbacks } = buildSpyCallbacks();
-      wireTransport(transport, callbacks);
-
-      await connect(transport, { authUrl: "https://auth.example/lk" });
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        "https://auth.example/lk",
-        expect.objectContaining({ method: "GET" })
-      );
-      expect(roomOf(transport).connect).toHaveBeenCalledWith(
-        "wss://fetched",
-        "fetched-tok",
-        undefined
-      );
-      expect(transport.state).toBe("connected");
-    });
-
-    test("_connect() with authUrl POST sends the JSON auth body", async () => {
-      const fetchMock = vi.fn(async () => ({
-        json: async () => ({ url: "wss://fetched", token: "fetched-tok" }),
-      }));
-      vi.stubGlobal("fetch", fetchMock);
-      const { callbacks } = buildSpyCallbacks();
-      wireTransport(transport, callbacks);
-
-      await connect(transport, {
-        authUrl: "https://auth.example/lk",
-        authMethod: "POST",
-        authBody: { roomName: "room-1" },
-      });
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        "https://auth.example/lk",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({ roomName: "room-1" }),
-        })
-      );
-    });
-
-    test("_connect() surfaces an authUrl fetch failure as TransportStartError + 'error' state", async () => {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async () => {
-          throw new Error("network down");
-        })
-      );
-      const { callbacks } = buildSpyCallbacks();
-      wireTransport(transport, callbacks);
-
-      await expect(
-        connect(transport, { authUrl: "https://auth.example/lk" })
-      ).rejects.toThrow("Failed to fetch credentials");
-      expect(transport.state).toBe("error");
+      expect(recorder.states).toEqual(["error"]);
     });
 
     test("_connect() surfaces a room.connect() failure as TransportStartError + 'error' state", async () => {
@@ -421,6 +400,25 @@ describe("LiveKitTransport — characterization", () => {
       ).not.toThrow();
       expect(onMessage).not.toHaveBeenCalled();
     });
+
+    test.each([
+      ["missing label", { id: "1", type: "server-message", data: {} }],
+      [
+        "non-rtvi label",
+        { id: "1", label: "not-rtvi", type: "server-message", data: {} },
+      ],
+    ])(
+      "inbound DataReceived with %s is ignored (handler not called)",
+      (_desc, message) => {
+        const { callbacks } = buildSpyCallbacks();
+        const { onMessage } = wireTransport(transport, callbacks);
+
+        const payload = new TextEncoder().encode(JSON.stringify(message));
+        roomOf(transport).emit(RoomEvent.DataReceived, payload);
+
+        expect(onMessage).not.toHaveBeenCalled();
+      }
+    );
   });
 
   describe("device management", () => {
@@ -455,6 +453,60 @@ describe("LiveKitTransport — characterization", () => {
       expect(spies.onDeviceError).toHaveBeenCalledTimes(1);
       expect(spies.onMicUpdated).not.toHaveBeenCalled();
     });
+
+    test.each([
+      ["audioinput", "NotAllowedError", ["mic"], "permissions"],
+      ["videoinput", "NotFoundError", ["cam"], "not-found"],
+      ["audioinput", "NotReadableError", ["mic"], "in-use"],
+      ["audiooutput", "GremlinError", ["speaker"], "unknown"],
+    ])(
+      "MediaDevicesError(kind=%s, %s) classifies onDeviceError as (%j, %s)",
+      (kind, errorName, devices, type) => {
+        const { callbacks, spies } = buildSpyCallbacks();
+        wireTransport(transport, callbacks);
+
+        const error = Object.assign(new Error("device failure"), {
+          name: errorName,
+        });
+        roomOf(transport).emit(RoomEvent.MediaDevicesError, error, kind);
+
+        expect(spies.onDeviceError).toHaveBeenCalledTimes(1);
+        expect(spies.onDeviceError).toHaveBeenCalledWith(
+          expect.objectContaining({ devices, type })
+        );
+      }
+    );
+
+    test("MediaDevicesError without a kind falls back to both cam+mic", () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      roomOf(transport).emit(
+        RoomEvent.MediaDevicesError,
+        new Error("no kind reported")
+      );
+
+      expect(spies.onDeviceError).toHaveBeenCalledWith(
+        expect.objectContaining({ devices: ["cam", "mic"], type: "unknown" })
+      );
+    });
+
+    test("MediaDevicesError without a kind uses lastMicrophoneError to pin the device", () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      roomOf(transport).localParticipant.lastMicrophoneError = new Error(
+        "mic boom"
+      );
+
+      roomOf(transport).emit(
+        RoomEvent.MediaDevicesError,
+        new Error("no kind reported")
+      );
+
+      expect(spies.onDeviceError).toHaveBeenCalledWith(
+        expect.objectContaining({ devices: ["mic"] })
+      );
+    });
   });
 
   describe("participants & tracks", () => {
@@ -474,6 +526,45 @@ describe("LiveKitTransport — characterization", () => {
         name: "Bot",
         local: false,
       });
+    });
+
+    test("LocalTrackPublished fires onTrackStarted for the published local track", () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      const mediaStreamTrack = {
+        getSettings: () => ({ deviceId: "cam-1" }),
+      } as unknown as MediaStreamTrack;
+      roomOf(transport).emit(
+        RoomEvent.LocalTrackPublished,
+        { source: Track.Source.Camera, track: { mediaStreamTrack } },
+        roomOf(transport).localParticipant
+      );
+
+      expect(spies.onTrackStarted).toHaveBeenCalledWith(
+        mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+    });
+
+    test("LocalTrackPublished resolves the selected camera and fires onCamUpdated", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      const mediaStreamTrack = {
+        getSettings: () => ({ deviceId: "cam-1" }),
+      } as unknown as MediaStreamTrack;
+      roomOf(transport).emit(
+        RoomEvent.LocalTrackPublished,
+        { source: Track.Source.Camera, track: { mediaStreamTrack } },
+        roomOf(transport).localParticipant
+      );
+
+      await vi.waitFor(() =>
+        expect(spies.onCamUpdated).toHaveBeenCalledWith(
+          expect.objectContaining({ deviceId: "cam-1" })
+        )
+      );
     });
 
     test("tracks() exposes the first remote participant's mic track as the bot audio", () => {

--- a/tests/src/transports/livekit.spec.ts
+++ b/tests/src/transports/livekit.spec.ts
@@ -22,6 +22,69 @@ import {
 } from "vitest";
 
 // ---- livekit-client mock ---------------------------------------------------
+// makeLocalTrack is shared between the mock factory below and the test body
+// (to fabricate pre-warmed tracks directly). vi.mock() factories are hoisted
+// above all imports/top-level code, so a normal module-scope helper wouldn't
+// be initialized yet when the factory runs — vi.hoisted() is what lets both
+// sides share it without smuggling it through the mocked module's own
+// exports (which would then have to type-check against the real
+// livekit-client .d.ts, which obviously has no such export).
+const { makeLocalTrack } = vi.hoisted(() => {
+  const freshRawTrack = (track: Record<string, unknown>) =>
+    ({
+      getSettings: () => ({ deviceId: track.__deviceId }),
+    }) as unknown as MediaStreamTrack;
+
+  // Fake pre-warmed local tracks returned by createLocalAudioTrack/
+  // createLocalVideoTrack, controllable per-test via mockResolvedValueOnce /
+  // mockRejectedValueOnce. mute()/unmute()/restartTrack() mirror the real
+  // LocalTrack API surface the transport now drives directly.
+  const makeLocalTrack = (deviceId: string, kind: string = "audio") => {
+    const track: Record<string, unknown> = {
+      kind,
+      mediaStreamTrack: {
+        getSettings: () => ({ deviceId: track.__deviceId }),
+      } as unknown as MediaStreamTrack,
+      isMuted: false,
+      __deviceId: deviceId,
+      stop: vi.fn(),
+      // Real LocalTrack.mute()/unmute() both no-op if already in that state
+      // (see livekit-client's own muteLock-guarded early return) — mirror
+      // that so a redundant call doesn't spuriously swap the raw track below.
+      mute: vi.fn(async function (this: Record<string, unknown>) {
+        if (this.isMuted) return;
+        this.isMuted = true;
+      }),
+      // Real LocalAudioTrack.unmute() doesn't restart (same raw track
+      // persists); real LocalVideoTrack.unmute() always calls restart()
+      // internally, swapping in a fresh raw track. Mirror that distinction so
+      // tests can observe onTrackStarted firing with the right object.
+      unmute: vi.fn(async function (this: Record<string, unknown>) {
+        if (!this.isMuted) return;
+        this.isMuted = false;
+        if (this.kind === "video") this.mediaStreamTrack = freshRawTrack(track);
+      }),
+      // restartTrack() always stops the old raw track and acquires a new one
+      // from getUserMedia — even when it lands on the same device.
+      restartTrack: vi.fn(async function (
+        this: Record<string, unknown>,
+        opts?: { deviceId?: string | { exact?: string; ideal?: string } }
+      ) {
+        if (opts?.deviceId) {
+          this.__deviceId =
+            typeof opts.deviceId === "string"
+              ? opts.deviceId
+              : (opts.deviceId.exact ?? opts.deviceId.ideal);
+        }
+        this.mediaStreamTrack = freshRawTrack(track);
+      }),
+    };
+    return track;
+  };
+
+  return { makeLocalTrack };
+});
+
 vi.mock("livekit-client", () => {
   const RoomEvent = {
     DataReceived: "dataReceived",
@@ -36,6 +99,10 @@ vi.mock("livekit-client", () => {
   };
 
   const Track = {
+    Kind: {
+      Audio: "audio",
+      Video: "video",
+    },
     Source: {
       Microphone: "microphone",
       Camera: "camera",
@@ -61,6 +128,20 @@ vi.mock("livekit-client", () => {
 
   class RemoteParticipant {}
 
+  const createLocalAudioTrack = vi.fn(async () =>
+    makeLocalTrack("mic-1", "audio")
+  );
+  const createLocalVideoTrack = vi.fn(async () =>
+    makeLocalTrack("cam-1", "video")
+  );
+  // createLocalTracks({audio: true, video: true}) — the combined-permission-
+  // prompt path. Defaults to acquiring both; tests can override per-call to
+  // simulate the all-or-nothing failure that triggers the individual fallback.
+  const createLocalTracks = vi.fn(async () => [
+    makeLocalTrack("mic-1", "audio"),
+    makeLocalTrack("cam-1", "video"),
+  ]);
+
   // Mirrors livekit-client's MediaDeviceFailure enum + getFailure() classifier
   // so the transport (which reads both from this same mocked module) stays
   // self-consistent under test.
@@ -84,12 +165,28 @@ vi.mock("livekit-client", () => {
     },
   };
 
+  // Mirrors livekit-client's ConnectionState — the transport gates
+  // createLocalAudioTrack-vs-setMicrophoneEnabled on this, not on Pipecat's
+  // own TransportState.
+  const ConnectionState = {
+    Disconnected: "disconnected",
+    Connecting: "connecting",
+    Connected: "connected",
+    Reconnecting: "reconnecting",
+    SignalReconnecting: "signal-reconnecting",
+  };
+
   class Room {
     options: unknown;
+    state: string = ConnectionState.Disconnected;
     localParticipant = new LocalParticipant();
     remoteParticipants = new Map<string, unknown>();
-    connect = vi.fn(async (_u: string, _t: string, _o?: unknown) => {});
-    disconnect = vi.fn(async () => {});
+    connect = vi.fn(async (_u: string, _t: string, _o?: unknown) => {
+      this.state = ConnectionState.Connected;
+    });
+    disconnect = vi.fn(async () => {
+      this.state = ConnectionState.Disconnected;
+    });
     switchActiveDevice = vi.fn(async (_k: string, _id: string) => {});
     private _handlers: Record<string, ((...a: unknown[]) => void)[]> = {};
     constructor(options?: unknown) {
@@ -108,15 +205,25 @@ vi.mock("livekit-client", () => {
     Room,
     RoomEvent,
     Track,
+    ConnectionState,
     LocalParticipant,
     RemoteParticipant,
     MediaDeviceFailure,
+    createLocalAudioTrack,
+    createLocalVideoTrack,
+    createLocalTracks,
   };
 });
 
 import { LiveKitTransport } from "@pipecat-ai/livekit-transport";
 // Values come from the mock above; only self-consistency with the source matters.
-import { RoomEvent, Track } from "livekit-client";
+import {
+  createLocalAudioTrack,
+  createLocalTracks,
+  createLocalVideoTrack,
+  RoomEvent,
+  Track,
+} from "livekit-client";
 
 import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
 
@@ -132,7 +239,6 @@ interface MediaDevicesStub {
   enumerateDevices: Mock;
   addEventListener: Mock;
   removeEventListener: Mock;
-  getUserMedia: Mock;
 }
 
 function stubMediaDevices(
@@ -142,9 +248,6 @@ function stubMediaDevices(
     enumerateDevices: vi.fn(async () => devices),
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
-    getUserMedia: vi.fn(
-      async () => ({ getTracks: () => [] }) as unknown as MediaStream
-    ),
   };
   Object.defineProperty(globalThis.navigator, "mediaDevices", {
     configurable: true,
@@ -155,6 +258,7 @@ function stubMediaDevices(
 
 // ---- internal fake-room accessor -------------------------------------------
 interface FakeRoom {
+  state: string;
   localParticipant: {
     isScreenShareEnabled: boolean;
     lastMicrophoneError: Error | undefined;
@@ -177,10 +281,32 @@ interface FakeRoom {
 const roomOf = (t: LiveKitTransport): FakeRoom =>
   (t as unknown as { _room: FakeRoom })._room;
 
+interface FakeLocalTrack {
+  mediaStreamTrack: MediaStreamTrack;
+  isMuted: boolean;
+  __deviceId: string;
+  stop: Mock;
+  mute: Mock;
+  unmute: Mock;
+  restartTrack: Mock;
+}
+
+const localAudioTrackOf = (t: LiveKitTransport): FakeLocalTrack | undefined =>
+  (t as unknown as { _localAudioTrack?: FakeLocalTrack })._localAudioTrack;
+const localVideoTrackOf = (t: LiveKitTransport): FakeLocalTrack | undefined =>
+  (t as unknown as { _localVideoTrack?: FakeLocalTrack })._localVideoTrack;
+
 // _connect / _validateConnectionParams take the non-exported LiveKitConnectParams;
 // cast loose test objects through this helper to stay readable.
 const connect = (t: LiveKitTransport, params: Record<string, unknown>) =>
   t._connect(params as never);
+
+// _handleDeviceChange is the private async body behind the devicechange
+// listener; invoking it directly (rather than pulling the listener off the
+// addEventListener mock and waiting out its internal microtask chain) keeps
+// these tests focused on behavior instead of timing.
+const triggerDeviceChange = (t: LiveKitTransport): Promise<void> =>
+  (t as unknown as { _handleDeviceChange(): Promise<void> })._handleDeviceChange();
 
 describe("LiveKitTransport — characterization", () => {
   let transport: LiveKitTransport;
@@ -189,6 +315,16 @@ describe("LiveKitTransport — characterization", () => {
   beforeEach(() => {
     mediaDevices = stubMediaDevices();
     transport = new LiveKitTransport();
+    (createLocalAudioTrack as Mock)
+      .mockReset()
+      .mockImplementation(async () => makeLocalTrack("mic-1", "audio"));
+    (createLocalVideoTrack as Mock)
+      .mockReset()
+      .mockImplementation(async () => makeLocalTrack("cam-1", "video"));
+    (createLocalTracks as Mock).mockReset().mockImplementation(async () => [
+      makeLocalTrack("mic-1", "audio"),
+      makeLocalTrack("cam-1", "video"),
+    ]);
   });
 
   afterEach(() => {
@@ -255,22 +391,189 @@ describe("LiveKitTransport — characterization", () => {
       expect(spies.onAvailableSpeakersUpdated).toHaveBeenLastCalledWith(
         expect.objectContaining({ length: 1 })
       );
+      // Default options enable mic only.
+      expect(createLocalAudioTrack).toHaveBeenCalledTimes(1);
+      expect(createLocalVideoTrack).not.toHaveBeenCalled();
+      expect(spies.onMicUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "mic-1" })
+      );
+      expect(spies.onTrackStarted).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ local: true })
+      );
+      expect(spies.onDeviceError).not.toHaveBeenCalled();
+      // Regression: selectedSpeaker used to stay {} until updateSpeaker() was
+      // called explicitly — nothing initialized it from the device list.
+      expect(spies.onSpeakerUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "spk-1" })
+      );
+      expect(
+        (transport.selectedSpeaker as MediaDeviceInfo).deviceId
+      ).toBe("spk-1");
     });
 
-    test("sendReadyMessage() flips to 'ready', waits for the participant, then publishes client-ready", async () => {
+    test("initDevices() selects the virtual 'default' speaker over other candidates when present", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      mediaDevices.enumerateDevices.mockResolvedValue([
+        ...DEFAULT_DEVICES,
+        {
+          kind: "audiooutput",
+          deviceId: "default",
+          label: "Default - Speaker 1",
+          groupId: "g3",
+        },
+      ]);
+
+      await transport.initDevices();
+
+      expect(spies.onSpeakerUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "default" })
+      );
+    });
+
+    test("initDevices() requests mic+cam together via createLocalTracks() when both are enabled", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: true, enableCam: true });
+
+      await transport.initDevices();
+
+      expect(createLocalTracks).toHaveBeenCalledTimes(1);
+      expect(createLocalTracks).toHaveBeenCalledWith({
+        audio: { deviceId: "default" },
+        video: { deviceId: "default" },
+      });
+      expect(createLocalAudioTrack).not.toHaveBeenCalled();
+      expect(createLocalVideoTrack).not.toHaveBeenCalled();
+      expect(spies.onMicUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "mic-1" })
+      );
+      expect(spies.onCamUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "cam-1" })
+      );
+    });
+
+    test("if the combined createLocalTracks() request fails, initDevices() falls back to acquiring each independently", async () => {
+      (createLocalTracks as Mock).mockRejectedValueOnce(
+        Object.assign(new Error("cam busy"), { name: "NotReadableError" })
+      );
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: true, enableCam: true });
+
+      await transport.initDevices();
+
+      expect(createLocalAudioTrack).toHaveBeenCalledTimes(1);
+      expect(createLocalVideoTrack).toHaveBeenCalledTimes(1);
+      expect(spies.onMicUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "mic-1" })
+      );
+      expect(spies.onCamUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "cam-1" })
+      );
+    });
+
+    test("initDevices() reports a mic acquisition failure through onDeviceError but still resolves", async () => {
+      (createLocalAudioTrack as Mock).mockRejectedValueOnce(
+        Object.assign(new Error("Permission denied"), {
+          name: "NotAllowedError",
+        })
+      );
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      await transport.initDevices();
+
+      expect(transport.state).toBe("initialized");
+      expect(spies.onDeviceError).toHaveBeenCalledTimes(1);
+      expect(spies.onDeviceError).toHaveBeenCalledWith(
+        expect.objectContaining({ devices: ["mic"], type: "permissions" })
+      );
+      expect(spies.onMicUpdated).not.toHaveBeenCalled();
+    });
+
+    test("initDevices() reports a cam acquisition failure through onDeviceError but still resolves", async () => {
+      (createLocalVideoTrack as Mock).mockRejectedValueOnce(
+        Object.assign(new Error("No camera found"), {
+          name: "NotFoundError",
+        })
+      );
+      const { callbacks, spies } = buildSpyCallbacks();
+      // mic disabled so this exercises the single-device (not combined
+      // createLocalTracks) acquisition path.
+      wireTransport(transport, callbacks, { enableMic: false, enableCam: true });
+
+      await transport.initDevices();
+
+      expect(transport.state).toBe("initialized");
+      expect(spies.onDeviceError).toHaveBeenCalledTimes(1);
+      expect(spies.onDeviceError).toHaveBeenCalledWith(
+        expect.objectContaining({ devices: ["cam"], type: "not-found" })
+      );
+      expect(spies.onCamUpdated).not.toHaveBeenCalled();
+    });
+
+    // "ready" means the bot can hear/see us and we can hear/see it — not just
+    // "connected to the room". So sendReadyMessage() only resolves right away
+    // if the bot's media is already subscribed; otherwise it waits for
+    // RoomEvent.TrackSubscribed. Mirrors the daily-transport contract.
+    test("sendReadyMessage() resolves immediately when the bot's media is already subscribed", async () => {
       const { callbacks, recorder } = buildSpyCallbacks();
       wireTransport(transport, callbacks);
       recorder.states.length = 0;
+
+      const bot = {
+        identity: "bot-1",
+        name: "Bot",
+        getTrackPublication: (s: string) =>
+          s === Track.Source.Microphone
+            ? { track: { mediaStreamTrack: {} } }
+            : undefined,
+      };
+      roomOf(transport).remoteParticipants.set("bot-1", bot);
+      roomOf(transport).emit(RoomEvent.ParticipantConnected, bot); // sets _botId
 
       await transport.sendReadyMessage();
 
       expect(transport.state).toBe("ready");
       expect(recorder.states).toEqual(["ready"]);
-      expect(roomOf(transport).localParticipant.waitUntilActive).toHaveBeenCalledTimes(1);
-      expect(roomOf(transport).localParticipant.publishData).toHaveBeenCalledWith(
-        expect.any(Uint8Array),
-        { reliable: true }
+      expect(
+        roomOf(transport).localParticipant.publishData
+      ).toHaveBeenCalledWith(expect.any(Uint8Array), { reliable: true });
+    });
+
+    test("sendReadyMessage() waits for a track to be subscribed before becoming ready", async () => {
+      const { callbacks, recorder } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      recorder.states.length = 0;
+
+      const bot = {
+        identity: "bot-1",
+        name: "Bot",
+        getTrackPublication: () => undefined,
+      };
+      roomOf(transport).remoteParticipants.set("bot-1", bot);
+      roomOf(transport).emit(RoomEvent.ParticipantConnected, bot);
+
+      const readyPromise = transport.sendReadyMessage();
+      await Promise.resolve();
+      expect(transport.state).not.toBe("ready");
+      expect(
+        roomOf(transport).localParticipant.publishData
+      ).not.toHaveBeenCalled();
+
+      roomOf(transport).emit(
+        RoomEvent.TrackSubscribed,
+        { kind: "audio", mediaStreamTrack: {} },
+        { source: Track.Source.Microphone },
+        bot
       );
+      await readyPromise;
+
+      expect(transport.state).toBe("ready");
+      expect(recorder.states).toEqual(["ready"]);
+      expect(
+        roomOf(transport).localParticipant.publishData
+      ).toHaveBeenCalledWith(expect.any(Uint8Array), { reliable: true });
     });
 
     test("_disconnect(): disconnecting → disconnected, disconnects room, removes listener, fires onDisconnected", async () => {
@@ -288,6 +591,17 @@ describe("LiveKitTransport — characterization", () => {
         expect.any(Function)
       );
       expect(spies.onDisconnected).toHaveBeenCalledTimes(1);
+    });
+
+    test("_disconnect() stops a pre-warmed track that was never published (e.g. connect() never ran)", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices();
+      const track = localAudioTrackOf(transport)!;
+
+      await transport._disconnect();
+
+      expect(track.stop).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -307,16 +621,52 @@ describe("LiveKitTransport — characterization", () => {
       expect(spies.onConnected).toHaveBeenCalledTimes(1);
     });
 
-    test("_connect() applies initialize()'s enableMic/enableCam to the local participant", async () => {
+    test("_connect() publishes tracks pre-warmed by initDevices(), alongside room.connect()", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: true, enableCam: true });
+      await transport.initDevices();
+      const audioTrack = localAudioTrackOf(transport);
+      const videoTrack = localVideoTrackOf(transport);
+
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+
+      expect(roomOf(transport).localParticipant.publishTrack).toHaveBeenCalledWith(
+        audioTrack
+      );
+      expect(roomOf(transport).localParticipant.publishTrack).toHaveBeenCalledWith(
+        videoTrack
+      );
+      expect(roomOf(transport).connect).toHaveBeenCalled();
+    });
+
+    test("_connect() publishes nothing when initDevices() was never called", async () => {
       const { callbacks } = buildSpyCallbacks();
       wireTransport(transport, callbacks, { enableMic: true, enableCam: false });
 
       await connect(transport, { url: "wss://lk.example", token: "tok" });
 
-      // With no pre-created (initDevices) tracks, an enabled device is turned
-      // on via setXEnabled(true); a disabled one is left untouched.
-      expect(roomOf(transport).localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(true);
-      expect(roomOf(transport).localParticipant.setCameraEnabled).not.toHaveBeenCalled();
+      expect(
+        roomOf(transport).localParticipant.publishTrack
+      ).not.toHaveBeenCalled();
+    });
+
+    test("a publish failure alongside a successful room.connect() does not fail the connection — it's reported via onDeviceError instead", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: true });
+      await transport.initDevices();
+      roomOf(transport).localParticipant.publishTrack.mockRejectedValueOnce(
+        new Error("publish rejected")
+      );
+
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+
+      // The room still connected fine — losing one track shouldn't sink the
+      // whole session.
+      expect(transport.state).toBe("connected");
+      expect(spies.onDeviceError).toHaveBeenCalledTimes(1);
+      expect(spies.onDeviceError).toHaveBeenCalledWith(
+        expect.objectContaining({ devices: ["mic"] })
+      );
     });
 
     test("_connect() without url/token throws TransportStartError and enters 'error'", async () => {
@@ -428,30 +778,356 @@ describe("LiveKitTransport — characterization", () => {
       expect(await transport.getAllSpeakers()).toHaveLength(1);
     });
 
-    test("updateMic() switches the active device and fires onMicUpdated", async () => {
+    test("updateMic() restarts the owned track on the new device and fires onMicUpdated", async () => {
       const { callbacks, spies } = buildSpyCallbacks();
       wireTransport(transport, callbacks);
+      await transport.initDevices();
+      const track = localAudioTrackOf(transport)!;
 
       await transport.updateMic("mic-2");
 
-      expect(roomOf(transport).switchActiveDevice).toHaveBeenCalledWith(
-        "audioinput",
-        "mic-2"
-      );
+      expect(track.restartTrack).toHaveBeenCalledWith({ deviceId: { exact: "mic-2" } });
       expect(spies.onMicUpdated).toHaveBeenCalledWith(
         expect.objectContaining({ deviceId: "mic-2" })
       );
     });
 
-    test("updateMic() reports a switch failure through onDeviceError", async () => {
+    test("updateMic() reports the device swap via onTrackStopped/onTrackStarted — restartTrack() always produces a new raw MediaStreamTrack", async () => {
       const { callbacks, spies } = buildSpyCallbacks();
       wireTransport(transport, callbacks);
-      roomOf(transport).switchActiveDevice.mockRejectedValueOnce(new Error("boom"));
+      await transport.initDevices();
+      const track = localAudioTrackOf(transport)!;
+      const oldRawTrack = track.mediaStreamTrack;
+      spies.onTrackStarted.mockClear();
+
+      await transport.updateMic("mic-2");
+
+      // restartTrack() genuinely swaps the raw track — onTrackStopped gets
+      // the old object, onTrackStarted the new (now-current) one.
+      expect(spies.onTrackStopped).toHaveBeenCalledWith(
+        oldRawTrack,
+        expect.objectContaining({ local: true })
+      );
+      expect(track.mediaStreamTrack).not.toBe(oldRawTrack);
+      expect(spies.onTrackStarted).toHaveBeenCalledWith(
+        track.mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+    });
+
+    test("updateMic() does not report a swap while muted — no valid media on either side of it", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices();
+      const track = localAudioTrackOf(transport)!;
+      await transport.enableMic(false);
+      spies.onTrackStarted.mockClear();
+      spies.onTrackStopped.mockClear();
+
+      await transport.updateMic("mic-2");
+
+      expect(track.restartTrack).toHaveBeenCalledWith({ deviceId: { exact: "mic-2" } });
+      expect(spies.onTrackStopped).not.toHaveBeenCalled();
+      expect(spies.onTrackStarted).not.toHaveBeenCalled();
+    });
+
+    test("updateMic() reports a restartTrack failure through onDeviceError", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices();
+      localAudioTrackOf(transport)!.restartTrack.mockRejectedValueOnce(
+        new Error("boom")
+      );
 
       await transport.updateMic("mic-2");
 
       expect(spies.onDeviceError).toHaveBeenCalledTimes(1);
-      expect(spies.onMicUpdated).not.toHaveBeenCalled();
+      expect(spies.onMicUpdated).not.toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "mic-2" })
+      );
+    });
+
+    test("updateMic() is a no-op when the mic was never enabled (no owned track to switch)", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: false });
+
+      await transport.updateMic("mic-2");
+
+      expect(createLocalAudioTrack).not.toHaveBeenCalled();
+    });
+
+    test("enableMic(false) then enableMic(true) mutes/unmutes the existing track in place", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices();
+      const track = localAudioTrackOf(transport)!;
+      (createLocalAudioTrack as Mock).mockClear();
+
+      await transport.enableMic(false);
+      expect(track.mute).toHaveBeenCalledTimes(1);
+
+      await transport.enableMic(true);
+      expect(track.unmute).toHaveBeenCalledTimes(1);
+      // Toggling reuses the existing track; it never re-acquires.
+      expect(createLocalAudioTrack).not.toHaveBeenCalled();
+    });
+
+    test("enableMic(true) with no existing track pre-warms one via createLocalAudioTrack() when not connected", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: false });
+
+      await transport.enableMic(true);
+
+      expect(createLocalAudioTrack).toHaveBeenCalledTimes(1);
+      expect(spies.onMicUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "mic-1" })
+      );
+      expect(
+        roomOf(transport).localParticipant.setMicrophoneEnabled
+      ).not.toHaveBeenCalled();
+    });
+
+    test("a failed enableMic(true) leaves isMicEnabled reflecting reality, not the attempted state", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: false });
+      (createLocalAudioTrack as Mock).mockRejectedValueOnce(
+        new Error("permission denied")
+      );
+
+      await transport.enableMic(true);
+
+      expect(transport.isMicEnabled).toBe(false);
+    });
+
+    test("a failed enableMic(false) leaves isMicEnabled reflecting reality, not the attempted state", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks); // default enableMic: true
+      await transport.initDevices();
+      localAudioTrackOf(transport)!.mute.mockRejectedValueOnce(
+        new Error("boom")
+      );
+
+      await transport.enableMic(false);
+
+      expect(transport.isMicEnabled).toBe(true);
+    });
+
+    test("enableMic(true) with no existing track uses setMicrophoneEnabled() once already connected", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: false });
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+      const publishedTrack = makeLocalTrack("mic-2");
+      roomOf(transport).localParticipant.getTrackPublication = vi.fn(
+        (s: string) =>
+          s === Track.Source.Microphone ? { track: publishedTrack } : undefined
+      );
+
+      await transport.enableMic(true);
+
+      expect(
+        roomOf(transport).localParticipant.setMicrophoneEnabled
+      ).toHaveBeenCalledWith(true);
+      expect(createLocalAudioTrack).not.toHaveBeenCalled();
+      expect(localAudioTrackOf(transport)).toBe(publishedTrack);
+      expect(spies.onMicUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "mic-2" })
+      );
+    });
+
+    test("enableMic(false)/(true) while already connected goes through setMicrophoneEnabled(), not a direct mute()/unmute() call", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices(); // acquires the track pre-connect
+      await connect(transport, { url: "wss://lk.example", token: "tok" }); // publishes it
+      const track = localAudioTrackOf(transport)!;
+      // The real setMicrophoneEnabled() resolves to track.mute()/unmute()
+      // internally when a publication already exists (that's the whole point
+      // of this test); our bare mock doesn't simulate that side effect, so
+      // apply it directly to make _syncSelectedMic()'s diff observable.
+      roomOf(transport).localParticipant.setMicrophoneEnabled.mockImplementation(
+        async (enable: boolean) => {
+          track.isMuted = !enable;
+        }
+      );
+
+      await transport.enableMic(false);
+      expect(
+        roomOf(transport).localParticipant.setMicrophoneEnabled
+      ).toHaveBeenCalledWith(false);
+      // We don't call mute() ourselves — setMicrophoneEnabled() already did
+      // — but we still have to report the transition, since mute()/unmute()
+      // never fire LocalTrackPublished/Unpublished.
+      expect(track.mute).not.toHaveBeenCalled();
+      expect(spies.onTrackStopped).toHaveBeenCalledWith(
+        track.mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+
+      await transport.enableMic(true);
+      expect(
+        roomOf(transport).localParticipant.setMicrophoneEnabled
+      ).toHaveBeenCalledWith(true);
+      expect(track.unmute).not.toHaveBeenCalled();
+      expect(spies.onTrackStarted).toHaveBeenCalledWith(
+        track.mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+    });
+
+    test("enableCam(false)/(true) while already connected goes through setCameraEnabled() and still re-syncs the selected device on enable", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: false, enableCam: true });
+      await transport.initDevices();
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+      const track = localVideoTrackOf(transport)!;
+      spies.onCamUpdated.mockClear();
+      // The real setCameraEnabled() resolves to track.mute()/unmute()
+      // internally when a publication already exists — our bare mock doesn't
+      // simulate that, so apply the equivalent state change directly
+      // (without going through the mute()/unmute() spies themselves, since
+      // this test asserts our own code doesn't separately call those).
+      roomOf(transport).localParticipant.setCameraEnabled.mockImplementation(
+        async (enable: boolean) => {
+          track.isMuted = !enable;
+          // LocalVideoTrack.unmute() always restarts internally, swapping in
+          // a fresh raw track — mirror that so the re-sync below is real.
+          if (enable) {
+            track.mediaStreamTrack = {
+              getSettings: () => ({ deviceId: track.__deviceId }),
+            } as unknown as MediaStreamTrack;
+          }
+        }
+      );
+
+      await transport.enableCam(false);
+      expect(
+        roomOf(transport).localParticipant.setCameraEnabled
+      ).toHaveBeenCalledWith(false);
+      expect(track.mute).not.toHaveBeenCalled();
+      expect(spies.onTrackStopped).toHaveBeenCalledWith(
+        track.mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+
+      // Simulate the original device having disappeared while muted — the
+      // restart-on-unmute above lands on a different one.
+      mediaDevices.enumerateDevices.mockResolvedValue([
+        ...DEFAULT_DEVICES,
+        { kind: "videoinput", deviceId: "cam-2", label: "Cam 2", groupId: "g2" },
+      ] as MediaDeviceInfo[]);
+      track.__deviceId = "cam-2";
+
+      await transport.enableCam(true);
+      expect(
+        roomOf(transport).localParticipant.setCameraEnabled
+      ).toHaveBeenCalledWith(true);
+      expect(spies.onCamUpdated).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: "cam-2" })
+      );
+      expect(spies.onTrackStarted).toHaveBeenCalledWith(
+        track.mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+    });
+
+    test("enableCam(false) stops the owned track outright (camera indicator turns off)", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: false, enableCam: true });
+      await transport.initDevices();
+      const track = localVideoTrackOf(transport)!;
+
+      await transport.enableCam(false);
+
+      // Mirrors livekit-client's own LocalVideoTrack.mute() semantics for
+      // camera sources: stop the hardware, don't just flip .enabled.
+      expect(track.mute).toHaveBeenCalledTimes(1);
+    });
+
+    test("enableCam(false)/(true) fire onTrackStopped/onTrackStarted, since mute()/unmute() swap the underlying MediaStreamTrack for camera sources", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: false, enableCam: true });
+      await transport.initDevices();
+      const track = localVideoTrackOf(transport)!;
+      const trackBeforeMute = track.mediaStreamTrack;
+      spies.onTrackStarted.mockClear();
+
+      await transport.enableCam(false);
+      expect(spies.onTrackStopped).toHaveBeenCalledWith(
+        trackBeforeMute,
+        expect.objectContaining({ local: true })
+      );
+
+      await transport.enableCam(true);
+      expect(spies.onTrackStarted).toHaveBeenCalledWith(
+        track.mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+    });
+
+    test("enableMic(false)/(true) fire onTrackStopped/onTrackStarted even though the same MediaStreamTrack persists throughout", async () => {
+      // onTrackStarted/onTrackStopped signal media validity, not literal
+      // object identity — a mute is exactly the transition callers need to
+      // hear about, even with the same instance under the hood.
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices();
+      const track = localAudioTrackOf(transport)!;
+      spies.onTrackStarted.mockClear();
+
+      await transport.enableMic(false);
+      expect(spies.onTrackStopped).toHaveBeenCalledWith(
+        track.mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+
+      await transport.enableMic(true);
+      expect(spies.onTrackStarted).toHaveBeenCalledWith(
+        track.mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+    });
+
+    test("a redundant enableMic(true) while already enabled does not re-fire onTrackStarted", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks); // default enableMic: true
+      await transport.initDevices();
+      spies.onTrackStarted.mockClear();
+
+      await transport.enableMic(true);
+
+      expect(spies.onTrackStarted).not.toHaveBeenCalled();
+      expect(spies.onTrackStopped).not.toHaveBeenCalled();
+    });
+
+    test("a redundant enableCam(true) while already enabled does not re-fire onTrackStarted", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: false, enableCam: true });
+      await transport.initDevices();
+      spies.onTrackStarted.mockClear();
+
+      await transport.enableCam(true);
+
+      expect(spies.onTrackStarted).not.toHaveBeenCalled();
+      expect(spies.onTrackStopped).not.toHaveBeenCalled();
+    });
+
+    test("_syncSelectedCam() doesn't re-fire onCamUpdated when re-synced to the same device", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableMic: false, enableCam: true });
+      await transport.initDevices(); // selects cam-1, fires onCamUpdated once
+      spies.onCamUpdated.mockClear();
+      const track = localVideoTrackOf(transport)!;
+
+      // Calling the sync helper again for the *same* already-selected device
+      // (e.g. from enableCam()'s unmute path, or a devicechange reselect that
+      // lands back on the same device) should stay quiet.
+      await (
+        transport as unknown as {
+          _syncSelectedCam(t: unknown): Promise<void>;
+        }
+      )._syncSelectedCam(track);
+
+      expect(spies.onCamUpdated).not.toHaveBeenCalled();
     });
 
     test.each([
@@ -509,6 +1185,132 @@ describe("LiveKitTransport — characterization", () => {
     });
   });
 
+  describe("devicechange reselection", () => {
+    // livekit-client's own Room already reselects a default audiooutput on
+    // devicechange (and updates every remote <audio> element's sinkId while
+    // doing it — see updateSpeaker()'s comment), but it deliberately skips
+    // audioinput/videoinput, so this is ours to handle.
+    test("a live mic whose selected device disappears is restarted onto a fresh default", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices(); // selects mic-1
+      const track = localAudioTrackOf(transport)!;
+
+      mediaDevices.enumerateDevices.mockResolvedValue(
+        DEFAULT_DEVICES.filter((d) => d.deviceId !== "mic-1")
+      );
+      track.restartTrack.mockImplementationOnce(async function (
+        this: typeof track
+      ) {
+        this.__deviceId = "mic-2";
+      });
+
+      await triggerDeviceChange(transport);
+
+      expect(track.restartTrack).toHaveBeenCalledWith({});
+      expect(spies.onMicUpdated).toHaveBeenLastCalledWith(
+        expect.objectContaining({ deviceId: "mic-2" })
+      );
+    });
+
+    test("a disabled cam (no live track) is left alone — nothing to reacquire", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, { enableCam: false });
+
+      mediaDevices.enumerateDevices.mockResolvedValue(
+        DEFAULT_DEVICES.filter((d) => d.kind !== "videoinput")
+      );
+
+      await expect(triggerDeviceChange(transport)).resolves.toBeUndefined();
+      expect(createLocalVideoTrack).not.toHaveBeenCalled();
+    });
+
+    test("nothing happens when the selected devices are all still present", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices();
+      const track = localAudioTrackOf(transport)!;
+      (track.restartTrack as Mock).mockClear();
+      spies.onMicUpdated.mockClear();
+
+      await triggerDeviceChange(transport);
+
+      expect(track.restartTrack).not.toHaveBeenCalled();
+      expect(spies.onMicUpdated).not.toHaveBeenCalled();
+    });
+
+    test("a restartTrack failure during reselection is reported through onDeviceError", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices();
+      const track = localAudioTrackOf(transport)!;
+
+      mediaDevices.enumerateDevices.mockResolvedValue(
+        DEFAULT_DEVICES.filter((d) => d.deviceId !== "mic-1")
+      );
+      track.restartTrack.mockRejectedValueOnce(new Error("no devices left"));
+
+      await triggerDeviceChange(transport);
+
+      expect(spies.onDeviceError).toHaveBeenCalledWith(
+        expect.objectContaining({ devices: ["mic"] })
+      );
+    });
+
+    // Regression: reacquiring by calling restartTrack({}) (no deviceId) picks
+    // up today's concrete default device, but getSettings().deviceId then
+    // reports *that device's own hash*, not "default" — silently converting
+    // "always follow the system default" into "pinned to whichever device
+    // happened to be default at the moment of the first devicechange". Every
+    // devicechange after that first one then sees a real (non-"default")
+    // current.deviceId, so defaultChanged can never be true again and
+    // reselection stops working. Explicitly requesting the virtual "default"
+    // device on every reselect keeps it sticky across repeated changes.
+    test("a mic following the system default keeps deviceId 'default' across repeated default changes", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await transport.initDevices(); // selects mic-1
+      const track = localAudioTrackOf(transport)!;
+
+      const devicesWithDefault = (label: string) => [
+        { kind: "audioinput", deviceId: "default", label, groupId: "g1" },
+        ...DEFAULT_DEVICES,
+      ];
+
+      mediaDevices.enumerateDevices.mockResolvedValue(
+        devicesWithDefault("Default - Mic 1")
+      );
+      await transport.updateMic("default");
+      expect((transport as unknown as { _selectedMic: MediaDeviceInfo })._selectedMic.deviceId).toBe("default");
+
+      // System default flips to Mic 2 — the "default" alias entry's label
+      // changes, but every device is still present.
+      mediaDevices.enumerateDevices.mockResolvedValue(
+        devicesWithDefault("Default - Mic 2")
+      );
+      await triggerDeviceChange(transport);
+
+      expect(track.restartTrack).toHaveBeenLastCalledWith({
+        deviceId: { exact: "default" },
+      });
+      expect(spies.onMicUpdated).toHaveBeenLastCalledWith(
+        expect.objectContaining({ deviceId: "default" })
+      );
+
+      // System default flips again, back to Mic 1. If the fix regressed
+      // (e.g. reacquiring with restartTrack({}) instead of the exact-default
+      // constraint) this second change would silently no-op.
+      mediaDevices.enumerateDevices.mockResolvedValue(
+        devicesWithDefault("Default - Mic 1")
+      );
+      await triggerDeviceChange(transport);
+
+      expect(track.restartTrack).toHaveBeenLastCalledWith({
+        deviceId: { exact: "default" },
+      });
+    });
+  });
+
   describe("participants & tracks", () => {
     test("ParticipantConnected maps a remote participant and fires onParticipantJoined", () => {
       const { callbacks, spies } = buildSpyCallbacks();
@@ -528,7 +1330,7 @@ describe("LiveKitTransport — characterization", () => {
       });
     });
 
-    test("LocalTrackPublished fires onTrackStarted for the published local track", () => {
+    test("LocalTrackPublished for a mic/cam source does not fire onTrackStarted (owned by initDevices()/enableMic()/enableCam() instead)", () => {
       const { callbacks, spies } = buildSpyCallbacks();
       wireTransport(transport, callbacks);
 
@@ -541,30 +1343,45 @@ describe("LiveKitTransport — characterization", () => {
         roomOf(transport).localParticipant
       );
 
-      expect(spies.onTrackStarted).toHaveBeenCalledWith(
+      expect(spies.onTrackStarted).not.toHaveBeenCalled();
+      expect(spies.onCamUpdated).not.toHaveBeenCalled();
+    });
+
+    test("LocalTrackPublished/Unpublished for a screen-share source fires onScreenTrackStarted/Stopped, not the generic onTrackStarted/Stopped", () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      const mediaStreamTrack = {} as MediaStreamTrack;
+      roomOf(transport).emit(
+        RoomEvent.LocalTrackPublished,
+        { source: Track.Source.ScreenShare, track: { mediaStreamTrack } },
+        roomOf(transport).localParticipant
+      );
+      roomOf(transport).emit(
+        RoomEvent.LocalTrackUnpublished,
+        { source: Track.Source.ScreenShare, track: { mediaStreamTrack } },
+        roomOf(transport).localParticipant
+      );
+
+      expect(spies.onScreenTrackStarted).toHaveBeenCalledWith(
         mediaStreamTrack,
         expect.objectContaining({ local: true })
       );
+      expect(spies.onScreenTrackStopped).toHaveBeenCalledWith(
+        mediaStreamTrack,
+        expect.objectContaining({ local: true })
+      );
+      expect(spies.onTrackStarted).not.toHaveBeenCalled();
+      expect(spies.onTrackStopped).not.toHaveBeenCalled();
     });
 
-    test("LocalTrackPublished resolves the selected camera and fires onCamUpdated", async () => {
-      const { callbacks, spies } = buildSpyCallbacks();
+    test("tracks(): local audio/video reflect the owned track even before connecting", async () => {
+      const { callbacks } = buildSpyCallbacks();
       wireTransport(transport, callbacks);
+      await transport.initDevices();
 
-      const mediaStreamTrack = {
-        getSettings: () => ({ deviceId: "cam-1" }),
-      } as unknown as MediaStreamTrack;
-      roomOf(transport).emit(
-        RoomEvent.LocalTrackPublished,
-        { source: Track.Source.Camera, track: { mediaStreamTrack } },
-        roomOf(transport).localParticipant
-      );
-
-      await vi.waitFor(() =>
-        expect(spies.onCamUpdated).toHaveBeenCalledWith(
-          expect.objectContaining({ deviceId: "cam-1" })
-        )
-      );
+      const track = localAudioTrackOf(transport)!;
+      expect(transport.tracks().local.audio).toBe(track.mediaStreamTrack);
     });
 
     test("tracks() exposes the bot participant's mic track as the bot audio", () => {

--- a/tests/src/transports/livekit.spec.ts
+++ b/tests/src/transports/livekit.spec.ts
@@ -567,21 +567,54 @@ describe("LiveKitTransport — characterization", () => {
       );
     });
 
-    test("tracks() exposes the first remote participant's mic track as the bot audio", () => {
+    test("tracks() exposes the bot participant's mic track as the bot audio", () => {
       const { callbacks } = buildSpyCallbacks();
       wireTransport(transport, callbacks);
 
       const botTrack = {} as MediaStreamTrack;
-      roomOf(transport).remoteParticipants.set("bot-1", {
+      const bot = {
         identity: "bot-1",
         name: "Bot",
         getTrackPublication: (s: string) =>
           s === Track.Source.Microphone
             ? { track: { mediaStreamTrack: botTrack } }
             : undefined,
-      });
+      };
+      roomOf(transport).remoteParticipants.set("bot-1", bot);
+      roomOf(transport).emit(RoomEvent.ParticipantConnected, bot);
 
       expect(transport.tracks().bot?.audio).toBe(botTrack);
+    });
+
+    test("first ParticipantConnected fires onBotConnected; its ParticipantDisconnected fires onBotDisconnected", () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      const bot = { identity: "bot-1", name: "Bot" };
+      const otherHuman = { identity: "human-1", name: "Human" };
+
+      roomOf(transport).emit(RoomEvent.ParticipantConnected, bot);
+      expect(spies.onBotConnected).toHaveBeenCalledTimes(1);
+      expect(spies.onBotConnected).toHaveBeenCalledWith({
+        id: "bot-1",
+        name: "Bot",
+        local: false,
+      });
+
+      // A second participant joining is not re-treated as the bot.
+      roomOf(transport).emit(RoomEvent.ParticipantConnected, otherHuman);
+      expect(spies.onBotConnected).toHaveBeenCalledTimes(1);
+
+      roomOf(transport).emit(RoomEvent.ParticipantDisconnected, otherHuman);
+      expect(spies.onBotDisconnected).not.toHaveBeenCalled();
+
+      roomOf(transport).emit(RoomEvent.ParticipantDisconnected, bot);
+      expect(spies.onBotDisconnected).toHaveBeenCalledTimes(1);
+      expect(spies.onBotDisconnected).toHaveBeenCalledWith({
+        id: "bot-1",
+        name: "Bot",
+        local: false,
+      });
     });
   });
 

--- a/tests/vitest.config.ts
+++ b/tests/vitest.config.ts
@@ -35,6 +35,10 @@ export default defineConfig({
         "../transports/moq-transport/src/index.ts",
         import.meta.url
       ).pathname,
+      "@pipecat-ai/livekit-transport": new URL(
+        "../transports/livekit-transport/src/index.ts",
+        import.meta.url
+      ).pathname,
     },
   },
 });

--- a/transports/livekit-transport/CHANGELOG.md
+++ b/transports/livekit-transport/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to **Pipecat LiveKit Transport** will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.8.1] - 2026-01-18
+
+### Added
+
+- Initial release of `@pipecat-ai/livekit-transport`
+- WebRTC transport implementation using LiveKit infrastructure
+- Complete device management for microphone, camera, and speaker
+- Support for flexible authentication via `authUrl` or direct `url`/`token`
+- Screen sharing functionality
+- Real-time messaging via LiveKit data channels
+- Comprehensive event handling for all LiveKit room events
+- Participant tracking and management
+- Transport state management aligned with Pipecat transport lifecycle
+- Full TypeScript type definitions
+- Integration with `@pipecat-ai/client-js` v1.13.0+
+
+### Features
+
+- 🎥 Camera device management with hot-swapping
+- 🎤 Microphone input handling with device switching
+- 🔊 Speaker output control
+- 📡 WebRTC connection management via LiveKit SDK
+- 🤖 Bot participant identification and tracking
+- 📺 Screen sharing with audio support
+- 💬 Real-time messaging and data channel communication
+- 🔐 Flexible authentication methods (auth URL or direct credentials)
+- ⚡ Automatic device enumeration and change detection
+- 🎯 Proper synchronization of device states
+
+### Dependencies
+
+- `livekit-client`: ^2.17.0
+- `@pipecat-ai/client-js`: ^1.13.0 (peer dependency)

--- a/transports/livekit-transport/CHANGELOG.md
+++ b/transports/livekit-transport/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **Pipecat LiveKit Transport** will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.1] - 2026-01-18
+## [1.0.0] - 2026-01-18
 
 ### Added
 

--- a/transports/livekit-transport/LICENSE
+++ b/transports/livekit-transport/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2024, Daily
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/transports/livekit-transport/README.md
+++ b/transports/livekit-transport/README.md
@@ -1,0 +1,213 @@
+# Pipecat's Real-Time Voice Inference - LiveKit Transport
+
+[![Docs](https://img.shields.io/badge/documentation-blue)](https://docs.pipecat.ai/client/js/transports/livekit)
+![NPM Version](https://img.shields.io/npm/v/@pipecat-ai/livekit-transport)
+
+LiveKit transport package for use with `@pipecat-ai/client-js`.
+
+## Installation
+
+```bash
+npm install \
+@pipecat-ai/client-js \
+@pipecat-ai/livekit-transport
+```
+
+## Overview
+
+The LiveKitTransport class provides a WebRTC transport layer using [LiveKit](https://livekit.io)'s infrastructure. It handles audio/video device management, WebRTC connections, and real-time communication between clients and bots through LiveKit's real-time media platform.
+
+## Features
+
+- 🎥 Complete camera device management
+- 🎤 Microphone input handling
+- 🔊 Speaker output control
+- 📡 WebRTC connection management via LiveKit
+- 🤖 Bot participant tracking
+- 📺 Screen sharing support
+- 💬 Real-time messaging via data channels
+- 🔐 Flexible authentication (auth URL or direct token)
+
+## Usage
+
+### Basic Setup with Auth URL
+
+```javascript
+import { PipecatClient } from "@pipecat-ai/client-js";
+import { LiveKitTransport } from "@pipecat-ai/livekit-transport";
+
+const pcClient = new PipecatClient({
+  transport: new LiveKitTransport(),
+  enableCam: false,  // Default camera off
+  enableMic: true,   // Default microphone on
+  callbacks: {
+    // Event handlers
+  },
+});
+
+// Auth credentials are passed to connect(), not the constructor
+await pcClient.connect({
+  authUrl: "https://your.server/livekit-auth",
+});
+```
+
+### Basic Setup with Direct Token
+
+```javascript
+import { PipecatClient } from "@pipecat-ai/client-js";
+import { LiveKitTransport } from "@pipecat-ai/livekit-transport";
+
+const pcClient = new PipecatClient({
+  transport: new LiveKitTransport(),
+  enableCam: false,
+  enableMic: true,
+  callbacks: {
+    onConnected: () => console.log("Connected to LiveKit room"),
+    onDisconnected: () => console.log("Disconnected from LiveKit room"),
+  },
+});
+
+await pcClient.connect({
+  url: "wss://your-livekit-server.com",
+  token: "your-livekit-access-token",
+});
+```
+
+## API Reference
+
+### Constructor Options
+
+The `LiveKitTransport` constructor accepts LiveKit `RoomOptions` to configure the room:
+
+```typescript
+type LiveKitTransportConstructorOptions = RoomOptions;
+
+// Example with custom room options
+const transport = new LiveKitTransport({
+  adaptiveStream: true,
+  dynacast: true,
+});
+```
+
+**Connection credentials** are passed to `pcClient.connect()`, not the constructor:
+
+```typescript
+// Auth URL (server returns { url, token })
+await pcClient.connect({ authUrl: "https://your.server/livekit-auth" });
+
+// Direct credentials
+await pcClient.connect({ url: "wss://your-livekit-server.com", token: "..." });
+
+// Auth URL with POST body
+await pcClient.connect({
+  authUrl: "https://your.server/livekit-auth",
+  authMethod: "POST",
+  authBody: { roomName: "my-room" },
+});
+```
+
+**RoomOptions** (from LiveKit SDK):
+- `adaptiveStream`: Enable/disable adaptive stream
+- `dynacast`: Enable/disable dynacast
+- `videoCaptureDefaults`: Default video capture settings
+- `audioCaptureDefaults`: Default audio capture settings
+- And other LiveKit-specific room options
+
+### Connection
+
+```javascript
+// With authUrl (credentials fetched automatically)
+await pcClient.connect();
+
+// With direct credentials (already provided in constructor)
+await pcClient.connect();
+```
+
+### Device Management
+
+```javascript
+// Get available devices
+const mics = await pcClient.getAllMics();
+const cams = await pcClient.getAllCams();
+const speakers = await pcClient.getAllSpeakers();
+
+// Update devices
+pcClient.updateMic(micDeviceId);
+pcClient.updateCam(camDeviceId);
+pcClient.updateSpeaker(speakerDeviceId);
+
+// Enable/disable devices
+pcClient.enableMic(true);
+pcClient.enableCam(true);
+
+// Check device status
+const isMicOn = pcClient.isMicEnabled;
+const isCamOn = pcClient.isCamEnabled;
+```
+
+### Screen Sharing
+
+```javascript
+// Enable screen sharing
+pcClient.enableScreenShare(true);
+
+// Check if screen sharing is active
+const isSharing = pcClient.isSharingScreen;
+
+// Disable screen sharing
+pcClient.enableScreenShare(false);
+```
+
+### States
+
+The transport can be in one of these states:
+- `"disconnected"` - Not connected to LiveKit room
+- `"initializing"` - Setting up devices
+- `"initialized"` - Devices ready
+- `"connecting"` - Connecting to LiveKit room
+- `"connected"` - Connected to LiveKit room
+- `"ready"` - Ready for communication
+- `"disconnecting"` - Disconnecting from room
+- `"error"` - An error occurred
+
+## Events
+
+The transport implements the various [Pipecat event handlers](https://docs.pipecat.ai/client/js/api-reference/callbacks):
+
+```javascript
+const pcClient = new PipecatClient({
+  transport: new LiveKitTransport({ authUrl: "..." }),
+  callbacks: {
+    onConnected: () => console.log("Connected"),
+    onDisconnected: () => console.log("Disconnected"),
+    onTransportStateChanged: (state) => console.log("State:", state),
+    onTrackStarted: (track, participant) => console.log("Track started"),
+    onTrackStopped: (track, participant) => console.log("Track stopped"),
+    onParticipantJoined: (participant) => console.log("Participant joined"),
+    onParticipantLeft: (participant) => console.log("Participant left"),
+    onMicUpdated: (deviceInfo) => console.log("Mic updated"),
+    onCamUpdated: (deviceInfo) => console.log("Camera updated"),
+    onSpeakerUpdated: (deviceInfo) => console.log("Speaker updated"),
+    onDeviceError: (error) => console.error("Device error:", error),
+  },
+});
+```
+
+## Error Handling
+
+The transport includes error handling for:
+- Connection failures
+- Device errors
+- Authentication issues
+- Media device access problems
+
+## Integration with LiveKit Server
+
+This transport is designed to work with LiveKit infrastructure. You'll need:
+1. A LiveKit server instance (self-hosted or LiveKit Cloud)
+2. An authentication endpoint that generates LiveKit access tokens, or
+3. A way to generate LiveKit tokens directly in your application
+
+## License
+
+BSD-2 Clause

--- a/transports/livekit-transport/README.md
+++ b/transports/livekit-transport/README.md
@@ -22,54 +22,37 @@ The LiveKitTransport class provides a WebRTC transport layer using [LiveKit](htt
 - 🎥 Complete camera device management
 - 🎤 Microphone input handling
 - 🔊 Speaker output control
-- 📡 WebRTC connection management via LiveKit
+- 📡 WebRTC connection management
 - 🤖 Bot participant tracking
 - 📺 Screen sharing support
 - 💬 Real-time messaging via data channels
-- 🔐 Flexible authentication (auth URL or direct token)
 
 ## Usage
 
-### Basic Setup with Auth URL
-
 ```javascript
 import { PipecatClient } from "@pipecat-ai/client-js";
 import { LiveKitTransport } from "@pipecat-ai/livekit-transport";
 
 const pcClient = new PipecatClient({
   transport: new LiveKitTransport(),
-  enableCam: false,  // Default camera off
-  enableMic: true,   // Default microphone on
+  enableMic: true,
+  enableCam: false,
   callbacks: {
-    // Event handlers
+    onConnected: () => console.log("Connected"),
+    onDisconnected: () => console.log("Disconnected"),
   },
 });
 
-// Auth credentials are passed to connect(), not the constructor
-await pcClient.connect({
-  authUrl: "https://your.server/livekit-auth",
-});
+// Fetch credentials from your server, then connect
+const { url, token } = await fetch("/your-token-endpoint").then(r => r.json());
+await pcClient.connect({ url, token });
 ```
 
-### Basic Setup with Direct Token
+Or use `startBotAndConnect()` to let the base client handle the fetch:
 
 ```javascript
-import { PipecatClient } from "@pipecat-ai/client-js";
-import { LiveKitTransport } from "@pipecat-ai/livekit-transport";
-
-const pcClient = new PipecatClient({
-  transport: new LiveKitTransport(),
-  enableCam: false,
-  enableMic: true,
-  callbacks: {
-    onConnected: () => console.log("Connected to LiveKit room"),
-    onDisconnected: () => console.log("Disconnected from LiveKit room"),
-  },
-});
-
-await pcClient.connect({
-  url: "wss://your-livekit-server.com",
-  token: "your-livekit-access-token",
+await pcClient.startBotAndConnect({
+  endpoint: "https://your.server/start-bot",
 });
 ```
 
@@ -77,7 +60,7 @@ await pcClient.connect({
 
 ### Constructor Options
 
-The `LiveKitTransport` constructor accepts LiveKit `RoomOptions` to configure the room:
+The `LiveKitTransport` constructor accepts LiveKit [`RoomOptions`](https://docs.livekit.io/reference/client-sdk-js/interfaces/RoomOptions.html) to configure the room:
 
 ```typescript
 type LiveKitTransportConstructorOptions = RoomOptions;
@@ -89,73 +72,25 @@ const transport = new LiveKitTransport({
 });
 ```
 
-**Connection credentials** are passed to `pcClient.connect()`, not the constructor:
+### Connection
+
+Pass `url` and `token` to `pcClient.connect()` at connection time:
 
 ```typescript
-// Auth URL (server returns { url, token })
-await pcClient.connect({ authUrl: "https://your.server/livekit-auth" });
-
-// Direct credentials
-await pcClient.connect({ url: "wss://your-livekit-server.com", token: "..." });
-
-// Auth URL with POST body
 await pcClient.connect({
-  authUrl: "https://your.server/livekit-auth",
-  authMethod: "POST",
-  authBody: { roomName: "my-room" },
+  url: "wss://your-livekit-server.com",
+  token: "your-livekit-access-token",
 });
 ```
 
-**RoomOptions** (from LiveKit SDK):
-- `adaptiveStream`: Enable/disable adaptive stream
-- `dynacast`: Enable/disable dynacast
-- `videoCaptureDefaults`: Default video capture settings
-- `audioCaptureDefaults`: Default audio capture settings
-- And other LiveKit-specific room options
+Optionally pass LiveKit [`RoomConnectOptions`](https://docs.livekit.io/reference/client-sdk-js/interfaces/RoomConnectOptions.html):
 
-### Connection
-
-```javascript
-// With authUrl (credentials fetched automatically)
-await pcClient.connect();
-
-// With direct credentials (already provided in constructor)
-await pcClient.connect();
-```
-
-### Device Management
-
-```javascript
-// Get available devices
-const mics = await pcClient.getAllMics();
-const cams = await pcClient.getAllCams();
-const speakers = await pcClient.getAllSpeakers();
-
-// Update devices
-pcClient.updateMic(micDeviceId);
-pcClient.updateCam(camDeviceId);
-pcClient.updateSpeaker(speakerDeviceId);
-
-// Enable/disable devices
-pcClient.enableMic(true);
-pcClient.enableCam(true);
-
-// Check device status
-const isMicOn = pcClient.isMicEnabled;
-const isCamOn = pcClient.isCamEnabled;
-```
-
-### Screen Sharing
-
-```javascript
-// Enable screen sharing
-pcClient.enableScreenShare(true);
-
-// Check if screen sharing is active
-const isSharing = pcClient.isSharingScreen;
-
-// Disable screen sharing
-pcClient.enableScreenShare(false);
+```typescript
+await pcClient.connect({
+  url: "wss://your-livekit-server.com",
+  token: "your-livekit-access-token",
+  roomConnectionOptions: { autoSubscribe: true },
+});
 ```
 
 ### States
@@ -172,41 +107,13 @@ The transport can be in one of these states:
 
 ## Events
 
-The transport implements the various [Pipecat event handlers](https://docs.pipecat.ai/client/js/api-reference/callbacks):
-
-```javascript
-const pcClient = new PipecatClient({
-  transport: new LiveKitTransport({ authUrl: "..." }),
-  callbacks: {
-    onConnected: () => console.log("Connected"),
-    onDisconnected: () => console.log("Disconnected"),
-    onTransportStateChanged: (state) => console.log("State:", state),
-    onTrackStarted: (track, participant) => console.log("Track started"),
-    onTrackStopped: (track, participant) => console.log("Track stopped"),
-    onParticipantJoined: (participant) => console.log("Participant joined"),
-    onParticipantLeft: (participant) => console.log("Participant left"),
-    onMicUpdated: (deviceInfo) => console.log("Mic updated"),
-    onCamUpdated: (deviceInfo) => console.log("Camera updated"),
-    onSpeakerUpdated: (deviceInfo) => console.log("Speaker updated"),
-    onDeviceError: (error) => console.error("Device error:", error),
-  },
-});
-```
-
-## Error Handling
-
-The transport includes error handling for:
-- Connection failures
-- Device errors
-- Authentication issues
-- Media device access problems
+The transport implements the standard [Pipecat event callbacks](https://docs.pipecat.ai/client/js/api-reference/callbacks). Refer to the docs for the full list of supported events and their signatures.
 
 ## Integration with LiveKit Server
 
 This transport is designed to work with LiveKit infrastructure. You'll need:
 1. A LiveKit server instance (self-hosted or LiveKit Cloud)
-2. An authentication endpoint that generates LiveKit access tokens, or
-3. A way to generate LiveKit tokens directly in your application
+2. A backend endpoint that generates LiveKit access tokens
 
 ## License
 

--- a/transports/livekit-transport/package.json
+++ b/transports/livekit-transport/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@pipecat-ai/livekit-transport",
+  "version": "1.8.1",
+  "license": "BSD-2-Clause",
+  "main": "dist/index.js",
+  "module": "dist/index.module.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pipecat-ai/pipecat-client-web-transports.git"
+  },
+  "files": [
+    "dist",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "parcel build --no-cache",
+    "dev": "parcel watch",
+    "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
+    "prepare": "npm run build"
+  },
+  "devDependencies": {
+    "@pipecat-ai/client-js": "^1.13.0",
+    "eslint": "9.39.1",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1"
+  },
+  "peerDependencies": {
+    "@pipecat-ai/client-js": "^1.13.0"
+  },
+  "dependencies": {
+    "livekit-client": "^2.21.0"
+  },
+  "description": "Pipecat Livekit Transport Package",
+  "author": "Himanshu Gunwant",
+  "bugs": {
+    "url": "https://github.com/pipecat-ai/pipecat-client-web-transports/issues"
+  }
+}

--- a/transports/livekit-transport/package.json
+++ b/transports/livekit-transport/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "^1.13.0"
+    "@pipecat-ai/client-js": "~1.13.0"
   },
   "dependencies": {
     "livekit-client": "^2.21.0"

--- a/transports/livekit-transport/package.json
+++ b/transports/livekit-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipecat-ai/livekit-transport",
-  "version": "1.8.1",
+  "version": "1.0.0",
   "license": "BSD-2-Clause",
   "main": "dist/index.js",
   "module": "dist/index.module.js",

--- a/transports/livekit-transport/src/index.ts
+++ b/transports/livekit-transport/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./liveKitTransport";

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -1,0 +1,557 @@
+import {
+  DeviceError,
+  Participant,
+  PipecatClientOptions,
+  RTVIEventCallbacks,
+  RTVIMessage,
+  Tracks,
+  Transport,
+  TransportStartError,
+  TransportState,
+  logger,
+} from "@pipecat-ai/client-js";
+import {
+  LocalParticipant,
+  LocalTrackPublication,
+  RemoteParticipant,
+  RemoteTrack,
+  RemoteTrackPublication,
+  Room,
+  RoomConnectOptions,
+  RoomEvent,
+  RoomOptions,
+  Track,
+} from "livekit-client";
+
+type LiveKitConnectParams = {
+  authUrl: string;
+  authMethod: "GET" | "POST";
+  authBody: Record<string, unknown>;
+
+  url: string;
+  token: string;
+
+  roomConnectionOptions: RoomConnectOptions;
+};
+
+export type LiveKitTransportConstructorOptions = RoomOptions;
+
+export class LiveKitTransport extends Transport {
+  private _room: Room;
+
+  private _selectedMic: MediaDeviceInfo | Record<string, never> = {};
+  private _selectedCam: MediaDeviceInfo | Record<string, never> = {};
+  private _selectedSpeaker: MediaDeviceInfo | Record<string, never> = {};
+
+  private _micEnabled: boolean = false;
+  private _camEnabled: boolean = false;
+  private _listenersAttached: boolean = false;
+  private _deviceChangeHandler = () => this.updateAvailableDevices();
+
+  protected _state: TransportState = "disconnected";
+  protected _callbacks: RTVIEventCallbacks = {};
+
+  constructor(options: LiveKitTransportConstructorOptions = {}) {
+    super();
+    this._room = new Room(options);
+  }
+
+  public initialize(
+    options: PipecatClientOptions,
+    messageHandler: (ev: RTVIMessage) => void
+  ): void {
+    this._options = options;
+    this._callbacks = options.callbacks ?? {};
+    this._onMessage = messageHandler;
+    this._micEnabled = options.enableMic ?? false;
+    this._camEnabled = options.enableCam ?? false;
+
+    this.attachEventListeners();
+
+    this.state = "disconnected";
+    logger.debug("[LiveKit Transport] Initialized");
+  }
+
+  get state(): TransportState {
+    return this._state;
+  }
+
+  set state(state: TransportState) {
+    if (this._state === state) return;
+
+    this._state = state;
+    this._callbacks.onTransportStateChanged?.(state);
+  }
+
+  async initDevices(): Promise<void> {
+    this.state = "initializing";
+
+    // In LiveKit, we can pre-warm devices or just enumerate
+    // We'll enumerate first
+    await this.updateAvailableDevices();
+
+    // Enable devices based on options if needed, but usually this happens on connect or explicitly
+    // For now, we just mark as initialized
+    this.state = "initialized";
+  }
+
+  private async updateAvailableDevices() {
+    // LiveKit helper for listing devices
+    // Note: LiveKit's Room doesn't strictly expose enumerateDevices directly as a static helper in all versions,
+    // but we can use navigator.mediaDevices directly or Room.getLocalDevices helper if available.
+    // We will use navigator.mediaDevices standard API for enumeration as it is robust.
+
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const cams = devices.filter((d) => d.kind === "videoinput");
+      const mics = devices.filter((d) => d.kind === "audioinput");
+      const speakers = devices.filter((d) => d.kind === "audiooutput");
+
+      this._callbacks.onAvailableCamsUpdated?.(cams);
+      this._callbacks.onAvailableMicsUpdated?.(mics);
+      this._callbacks.onAvailableSpeakersUpdated?.(speakers);
+
+      // We can't easily know "selected" device without querying the Room's LocalParticipant or active device
+      // But initially none is selected until we start tracks.
+    } catch (e) {
+      logger.error("Error enumerating devices", e);
+    }
+  }
+
+  _validateConnectionParams(
+    connectParams: unknown
+  ): LiveKitConnectParams | undefined {
+    if (!connectParams || typeof connectParams !== "object") return undefined;
+    return connectParams as LiveKitConnectParams;
+  }
+
+  async _connect(connectParams?: LiveKitConnectParams): Promise<void> {
+    const params = connectParams || ({} as Partial<LiveKitConnectParams>);
+    let { url, token } = params;
+
+    this.state = "connecting";
+    if (params.authUrl) {
+      try {
+        const options: RequestInit = {
+          method: params.authMethod ?? "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        };
+        if (options.method?.toUpperCase() == "POST") {
+          options.body = JSON.stringify(params.authBody ?? {});
+        }
+        const res = await fetch(params.authUrl, options);
+        const json = await res.json();
+        url = json.url;
+        token = json.token;
+      } catch (e) {
+        logger.error("Failed to fetch LiveKit credentials from authUrl", e);
+        this.state = "error";
+        throw new TransportStartError("Failed to fetch credentials");
+      }
+    }
+
+    if (!url || !token) {
+      logger.error(
+        "LiveKit connection requires 'url' and 'token' or 'authUrl'"
+      );
+      this.state = "error";
+      throw new TransportStartError("Missing url or token");
+    }
+
+    try {
+      await this._room.connect(url, token, params.roomConnectionOptions);
+      const enableMic = this._micEnabled;
+      const enableCam = this._camEnabled;
+      await this._room.localParticipant.setMicrophoneEnabled(enableMic);
+      if (enableMic) {
+        const trackPub = this._room.localParticipant.getTrackPublication(
+          Track.Source.Microphone
+        );
+        if (trackPub?.track?.mediaStreamTrack) {
+          const deviceId =
+            trackPub.track.mediaStreamTrack.getSettings().deviceId;
+          if (deviceId) {
+            const mics = await this.getAllMics();
+            const mic = mics.find((m) => m.deviceId === deviceId);
+            if (mic) this._selectedMic = mic;
+          }
+        }
+      }
+      if (this._isMediaDeviceInfo(this._selectedMic)) {
+        this._callbacks.onMicUpdated?.(this._selectedMic);
+      }
+      await this._room.localParticipant.setCameraEnabled(enableCam);
+      if (this._isMediaDeviceInfo(this._selectedCam)) {
+        this._callbacks.onCamUpdated?.(this._selectedCam);
+      }
+    } catch (e) {
+      logger.error("Failed to connect to LiveKit room", e);
+      this.state = "error";
+      throw new TransportStartError();
+    }
+
+    if (this._abortController?.signal.aborted) {
+      await this._room.disconnect();
+      return;
+    }
+
+    this.state = "connected";
+    this._callbacks.onConnected?.();
+  }
+
+  async _disconnect(): Promise<void> {
+    this.state = "disconnecting";
+    navigator.mediaDevices.removeEventListener(
+      "devicechange",
+      this._deviceChangeHandler
+    );
+    await this._room.disconnect();
+    this.state = "disconnected";
+    this._callbacks.onDisconnected?.();
+  }
+
+  sendMessage(message: RTVIMessage): void {
+    if (!this._room || (this.state !== "connected" && this.state !== "ready")) {
+      logger.warn("Cannot send message, not connected");
+      return;
+    }
+    const str = JSON.stringify(message);
+    const encoder = new TextEncoder();
+    const data = encoder.encode(str);
+
+    // Publish to room
+    this._room.localParticipant.publishData(data, { reliable: true });
+  }
+
+  // Device Management
+  async getAllMics(): Promise<MediaDeviceInfo[]> {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.filter((d) => d.kind === "audioinput");
+  }
+
+  async getAllCams(): Promise<MediaDeviceInfo[]> {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.filter((d) => d.kind === "videoinput");
+  }
+
+  async getAllSpeakers(): Promise<MediaDeviceInfo[]> {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.filter((d) => d.kind === "audiooutput");
+  }
+
+  async updateMic(micId: string): Promise<void> {
+    try {
+      await this._room.switchActiveDevice("audioinput", micId);
+      const mics = await this.getAllMics();
+      const mic = mics.find((m) => m.deviceId === micId);
+      if (mic) {
+        this._selectedMic = mic;
+        this._callbacks.onMicUpdated?.(mic);
+      }
+    } catch (e: unknown) {
+      this._callbacks.onDeviceError?.(
+        new DeviceError(["mic"], "unknown", (e as Error).message)
+      );
+    }
+  }
+
+  async updateCam(camId: string): Promise<void> {
+    try {
+      await this._room.switchActiveDevice("videoinput", camId);
+      const cams = await this.getAllCams();
+      const cam = cams.find((c) => c.deviceId === camId);
+      if (cam) {
+        this._selectedCam = cam;
+        this._callbacks.onCamUpdated?.(cam);
+      }
+    } catch (e: unknown) {
+      this._callbacks.onDeviceError?.(
+        new DeviceError(["cam"], "unknown", (e as Error).message)
+      );
+    }
+  }
+
+  async updateSpeaker(speakerId: string): Promise<void> {
+    try {
+      await this._room.switchActiveDevice("audiooutput", speakerId);
+      const speakers = await this.getAllSpeakers();
+      const s = speakers.find((d) => d.deviceId === speakerId);
+      if (s) {
+        this._selectedSpeaker = s;
+        this._callbacks.onSpeakerUpdated?.(s);
+      }
+    } catch (e: unknown) {
+      this._callbacks.onDeviceError?.(
+        new DeviceError(["speaker"], "unknown", (e as Error).message)
+      );
+    }
+  }
+
+  get selectedMic() {
+    return this._selectedMic;
+  }
+  get selectedCam() {
+    return this._selectedCam;
+  }
+  get selectedSpeaker() {
+    return this._selectedSpeaker;
+  }
+
+  enableMic(enable: boolean): void {
+    this._room.localParticipant
+      .setMicrophoneEnabled(enable)
+      .then(async () => {
+        this._micEnabled = enable;
+        if (enable) {
+          const trackPub = this._room.localParticipant.getTrackPublication(
+            Track.Source.Microphone
+          );
+          const deviceId =
+            trackPub?.track?.mediaStreamTrack?.getSettings().deviceId;
+          if (deviceId) {
+            const mics = await this.getAllMics();
+            const mic = mics.find((m) => m.deviceId === deviceId);
+            if (mic) this._selectedMic = mic;
+          }
+        }
+        if (this._isMediaDeviceInfo(this._selectedMic)) {
+          this._callbacks.onMicUpdated?.(this._selectedMic);
+        }
+      })
+      .catch((e) => {
+        logger.error("Failed to toggle mic", e);
+        this._callbacks.onDeviceError?.(
+          new DeviceError(["mic"], "unknown", e.message)
+        );
+      });
+  }
+
+  enableCam(enable: boolean): void {
+    this._room.localParticipant
+      .setCameraEnabled(enable)
+      .then(async () => {
+        this._camEnabled = enable;
+        if (enable) {
+          const trackPub = this._room.localParticipant.getTrackPublication(
+            Track.Source.Camera
+          );
+          const deviceId =
+            trackPub?.track?.mediaStreamTrack?.getSettings().deviceId;
+          if (deviceId) {
+            const cams = await this.getAllCams();
+            const cam = cams.find((c) => c.deviceId === deviceId);
+            if (cam) this._selectedCam = cam;
+          }
+        }
+        if (this._isMediaDeviceInfo(this._selectedCam)) {
+          this._callbacks.onCamUpdated?.(this._selectedCam);
+        }
+      })
+      .catch((e) => {
+        logger.error("Failed to toggle cam", e);
+        this._callbacks.onDeviceError?.(
+          new DeviceError(["cam"], "unknown", e.message)
+        );
+      });
+  }
+
+  private _isMediaDeviceInfo(
+    device: MediaDeviceInfo | Record<string, never>
+  ): device is MediaDeviceInfo {
+    return (device as MediaDeviceInfo).deviceId !== undefined;
+  }
+
+  get isMicEnabled(): boolean {
+    return this._micEnabled;
+  }
+
+  get isCamEnabled(): boolean {
+    return this._camEnabled;
+  }
+
+  get isSharingScreen(): boolean {
+    return this._room.localParticipant.isScreenShareEnabled;
+  }
+
+  enableScreenShare(enable: boolean): void {
+    this._room.localParticipant.setScreenShareEnabled(enable);
+  }
+
+  tracks(): Tracks {
+    const local = this._room.localParticipant;
+    const getTrack = (
+      p: LocalParticipant | RemoteParticipant,
+      _kind: string,
+      source: Track.Source
+    ) => {
+      const pub = p.getTrackPublication(source);
+      return pub?.track?.mediaStreamTrack;
+    };
+
+    const localTracks = {
+      audio: getTrack(local, "audio", Track.Source.Microphone),
+      video: getTrack(local, "video", Track.Source.Camera),
+      screenVideo: getTrack(local, "video", Track.Source.ScreenShare),
+      screenAudio: getTrack(local, "audio", Track.Source.ScreenShareAudio),
+    };
+
+    // Uses first remote participant as bot; no explicit bot identity API yet.
+    const remoteParticipants = Array.from(
+      this._room.remoteParticipants.values()
+    );
+    const botParticipant = remoteParticipants[0];
+    const botTracks = botParticipant
+      ? {
+          audio: getTrack(botParticipant, "audio", Track.Source.Microphone),
+          video: getTrack(botParticipant, "video", Track.Source.Camera),
+        }
+      : {};
+
+    return { local: localTracks, bot: botTracks };
+  }
+
+  async sendReadyMessage() {
+    this.state = "ready";
+    await this._room.localParticipant.waitUntilActive();
+    this.sendMessage(RTVIMessage.clientReady());
+  }
+
+  private attachEventListeners() {
+    if (this._listenersAttached) return;
+    this._listenersAttached = true;
+
+    this._room
+      .on(RoomEvent.DataReceived, this.handleDataReceived.bind(this))
+      .on(RoomEvent.TrackSubscribed, this.handleTrackSubscribed.bind(this))
+      .on(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed.bind(this))
+      .on(
+        RoomEvent.ParticipantConnected,
+        this.handleParticipantConnected.bind(this)
+      )
+      .on(
+        RoomEvent.ParticipantDisconnected,
+        this.handleParticipantDisconnected.bind(this)
+      )
+      .on(RoomEvent.Disconnected, this.handleRoomDisconnected.bind(this))
+      .on(
+        RoomEvent.LocalTrackPublished,
+        this.handleLocalTrackPublished.bind(this)
+      )
+      .on(
+        RoomEvent.LocalTrackUnpublished,
+        this.handleLocalTrackUnpublished.bind(this)
+      )
+      .on(RoomEvent.MediaDevicesError, this.handleMediaDevicesError.bind(this));
+
+    navigator.mediaDevices.addEventListener(
+      "devicechange",
+      this._deviceChangeHandler
+    );
+  }
+
+  private handleDataReceived(payload: Uint8Array) {
+    try {
+      const decoder = new TextDecoder();
+      const str = decoder.decode(payload);
+      const msg = JSON.parse(str);
+      if (msg && typeof msg === "object" && "type" in msg) {
+        this._onMessage(msg as RTVIMessage);
+      }
+    } catch (e) {
+      logger.warn("Failed to parse data message", e);
+    }
+  }
+
+  private handleTrackSubscribed(
+    track: RemoteTrack,
+    publication: RemoteTrackPublication,
+    participant: RemoteParticipant
+  ) {
+    this._callbacks.onTrackStarted?.(
+      track.mediaStreamTrack,
+      this.toParticipant(participant)
+    );
+  }
+
+  private handleTrackUnsubscribed(
+    track: RemoteTrack,
+    publication: RemoteTrackPublication,
+    participant: RemoteParticipant
+  ) {
+    if (track.mediaStreamTrack) {
+      this._callbacks.onTrackStopped?.(
+        track.mediaStreamTrack,
+        this.toParticipant(participant)
+      );
+    }
+  }
+
+  private handleLocalTrackPublished(
+    publication: LocalTrackPublication,
+    participant: LocalParticipant
+  ) {
+    if (publication.track?.mediaStreamTrack) {
+      this._callbacks.onTrackStarted?.(
+        publication.track.mediaStreamTrack,
+        this.toParticipant(participant)
+      );
+    }
+    if (publication.source === Track.Source.Microphone) {
+      const deviceId =
+        publication.track?.mediaStreamTrack?.getSettings().deviceId;
+      if (deviceId) {
+        this.getAllMics().then((mics) => {
+          const mic = mics.find((m) => m.deviceId === deviceId);
+          if (mic) {
+            this._selectedMic = mic;
+            this._callbacks.onMicUpdated?.(mic);
+          }
+        });
+      }
+    }
+  }
+
+  private handleLocalTrackUnpublished(
+    publication: LocalTrackPublication,
+    participant: LocalParticipant
+  ) {
+    if (publication.track?.mediaStreamTrack) {
+      this._callbacks.onTrackStopped?.(
+        publication.track.mediaStreamTrack,
+        this.toParticipant(participant)
+      );
+    }
+  }
+
+  private handleParticipantConnected(participant: RemoteParticipant) {
+    this._callbacks.onParticipantJoined?.(this.toParticipant(participant));
+    // Potential bot identification logic here
+  }
+
+  private handleParticipantDisconnected(participant: RemoteParticipant) {
+    this._callbacks.onParticipantLeft?.(this.toParticipant(participant));
+  }
+
+  private handleRoomDisconnected() {
+    if (this.state !== "disconnected") {
+      this.state = "disconnected";
+      this._callbacks.onDisconnected?.();
+    }
+  }
+
+  private handleMediaDevicesError(e: Error) {
+    this._callbacks.onDeviceError?.(
+      new DeviceError(["cam", "mic"], "unknown", e.message)
+    );
+  }
+
+  private toParticipant(p: LocalParticipant | RemoteParticipant): Participant {
+    return {
+      id: p.identity,
+      name: p.name || "",
+      local: p instanceof LocalParticipant,
+    };
+  }
+}

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -2,7 +2,6 @@ import {
   DeviceError,
   Participant,
   PipecatClientOptions,
-  RTVIEventCallbacks,
   RTVIMessage,
   Tracks,
   Transport,
@@ -22,16 +21,12 @@ import {
   RoomOptions,
   Track,
 } from "livekit-client";
+import packageJson from "../package.json";
 
-type LiveKitConnectParams = {
-  authUrl: string;
-  authMethod: "GET" | "POST";
-  authBody: Record<string, unknown>;
-
+export type LiveKitConnectParams = {
   url: string;
   token: string;
-
-  roomConnectionOptions: RoomConnectOptions;
+  roomConnectionOptions?: RoomConnectOptions;
 };
 
 export type LiveKitTransportConstructorOptions = RoomOptions;
@@ -48,9 +43,6 @@ export class LiveKitTransport extends Transport {
   private _listenersAttached: boolean = false;
   private _deviceChangeHandler = () => this.updateAvailableDevices();
 
-  protected _state: TransportState = "disconnected";
-  protected _callbacks: RTVIEventCallbacks = {};
-
   constructor(options: LiveKitTransportConstructorOptions = {}) {
     super();
     this._room = new Room(options);
@@ -63,13 +55,13 @@ export class LiveKitTransport extends Transport {
     this._options = options;
     this._callbacks = options.callbacks ?? {};
     this._onMessage = messageHandler;
-    this._micEnabled = options.enableMic ?? false;
+    this._micEnabled = options.enableMic ?? true;
     this._camEnabled = options.enableCam ?? false;
 
     this.attachEventListeners();
 
     this.state = "disconnected";
-    logger.debug("[LiveKit Transport] Initialized");
+    logger.debug("[LiveKit Transport] Initialized", packageJson.version);
   }
 
   get state(): TransportState {
@@ -86,21 +78,50 @@ export class LiveKitTransport extends Transport {
   async initDevices(): Promise<void> {
     this.state = "initializing";
 
-    // In LiveKit, we can pre-warm devices or just enumerate
-    // We'll enumerate first
-    await this.updateAvailableDevices();
+    if (this._micEnabled || this._camEnabled) {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: this._micEnabled,
+          video: this._camEnabled,
+        });
 
-    // Enable devices based on options if needed, but usually this happens on connect or explicitly
-    // For now, we just mark as initialized
+        await this.updateAvailableDevices();
+
+        const audioTrack = stream.getAudioTracks()[0];
+        if (audioTrack) {
+          const deviceId = audioTrack.getSettings().deviceId;
+          const mics = await this.getAllMics();
+          const mic = mics.find((m) => m.deviceId === deviceId);
+          if (mic) {
+            this._selectedMic = mic;
+            this._callbacks.onMicUpdated?.(mic);
+          }
+          audioTrack.stop();
+        }
+
+        const videoTrack = stream.getVideoTracks()[0];
+        if (videoTrack) {
+          const deviceId = videoTrack.getSettings().deviceId;
+          const cams = await this.getAllCams();
+          const cam = cams.find((c) => c.deviceId === deviceId);
+          if (cam) {
+            this._selectedCam = cam;
+            this._callbacks.onCamUpdated?.(cam);
+          }
+          videoTrack.stop();
+        }
+      } catch (e) {
+        logger.warn("[LiveKit Transport] Could not initialize devices", e);
+        await this.updateAvailableDevices();
+      }
+    } else {
+      await this.updateAvailableDevices();
+    }
+
     this.state = "initialized";
   }
 
   private async updateAvailableDevices() {
-    // LiveKit helper for listing devices
-    // Note: LiveKit's Room doesn't strictly expose enumerateDevices directly as a static helper in all versions,
-    // but we can use navigator.mediaDevices directly or Room.getLocalDevices helper if available.
-    // We will use navigator.mediaDevices standard API for enumeration as it is robust.
-
     try {
       const devices = await navigator.mediaDevices.enumerateDevices();
       const cams = devices.filter((d) => d.kind === "videoinput");
@@ -110,9 +131,6 @@ export class LiveKitTransport extends Transport {
       this._callbacks.onAvailableCamsUpdated?.(cams);
       this._callbacks.onAvailableMicsUpdated?.(mics);
       this._callbacks.onAvailableSpeakersUpdated?.(speakers);
-
-      // We can't easily know "selected" device without querying the Room's LocalParticipant or active device
-      // But initially none is selected until we start tracks.
     } catch (e) {
       logger.error("Error enumerating devices", e);
     }
@@ -122,80 +140,35 @@ export class LiveKitTransport extends Transport {
     connectParams: unknown
   ): LiveKitConnectParams | undefined {
     if (!connectParams || typeof connectParams !== "object") return undefined;
-    return connectParams as LiveKitConnectParams;
+    const p = connectParams as LiveKitConnectParams;
+    if (!p.url || !p.token) {
+      throw new Error("LiveKit connection requires 'url' and 'token'");
+    }
+    return p;
   }
 
   async _connect(connectParams?: LiveKitConnectParams): Promise<void> {
-    const params = connectParams || ({} as Partial<LiveKitConnectParams>);
-    let { url, token } = params;
+    if (!connectParams?.url || !connectParams?.token) {
+      this.state = "error";
+      throw new TransportStartError("LiveKit connection requires 'url' and 'token'");
+    }
 
     this.state = "connecting";
-    if (params.authUrl) {
-      try {
-        const options: RequestInit = {
-          method: params.authMethod ?? "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        };
-        if (options.method?.toUpperCase() == "POST") {
-          options.body = JSON.stringify(params.authBody ?? {});
-        }
-        const res = await fetch(params.authUrl, options);
-        const json = await res.json();
-        url = json.url;
-        token = json.token;
-      } catch (e) {
-        logger.error("Failed to fetch LiveKit credentials from authUrl", e);
-        this.state = "error";
-        throw new TransportStartError("Failed to fetch credentials");
-      }
-    }
-
-    if (!url || !token) {
-      logger.error(
-        "LiveKit connection requires 'url' and 'token' or 'authUrl'"
-      );
-      this.state = "error";
-      throw new TransportStartError("Missing url or token");
-    }
 
     try {
-      await this._room.connect(url, token, params.roomConnectionOptions);
-      const enableMic = this._micEnabled;
-      const enableCam = this._camEnabled;
-      await this._room.localParticipant.setMicrophoneEnabled(enableMic);
-      if (enableMic) {
-        const trackPub = this._room.localParticipant.getTrackPublication(
-          Track.Source.Microphone
-        );
-        if (trackPub?.track?.mediaStreamTrack) {
-          const deviceId =
-            trackPub.track.mediaStreamTrack.getSettings().deviceId;
-          if (deviceId) {
-            const mics = await this.getAllMics();
-            const mic = mics.find((m) => m.deviceId === deviceId);
-            if (mic) this._selectedMic = mic;
-          }
-        }
-      }
-      if (this._isMediaDeviceInfo(this._selectedMic)) {
-        this._callbacks.onMicUpdated?.(this._selectedMic);
-      }
-      await this._room.localParticipant.setCameraEnabled(enableCam);
-      if (this._isMediaDeviceInfo(this._selectedCam)) {
-        this._callbacks.onCamUpdated?.(this._selectedCam);
-      }
+      await this._room.connect(
+        connectParams.url,
+        connectParams.token,
+        connectParams.roomConnectionOptions
+      );
     } catch (e) {
       logger.error("Failed to connect to LiveKit room", e);
       this.state = "error";
       throw new TransportStartError();
     }
 
-    if (this._abortController?.signal.aborted) {
-      await this._room.disconnect();
-      return;
-    }
+    await this._room.localParticipant.setMicrophoneEnabled(this._micEnabled);
+    await this._room.localParticipant.setCameraEnabled(this._camEnabled);
 
     this.state = "connected";
     this._callbacks.onConnected?.();
@@ -213,15 +186,10 @@ export class LiveKitTransport extends Transport {
   }
 
   sendMessage(message: RTVIMessage): void {
-    if (!this._room || (this.state !== "connected" && this.state !== "ready")) {
-      logger.warn("Cannot send message, not connected");
-      return;
-    }
     const str = JSON.stringify(message);
     const encoder = new TextEncoder();
     const data = encoder.encode(str);
 
-    // Publish to room
     this._room.localParticipant.publishData(data, { reliable: true });
   }
 
@@ -242,6 +210,7 @@ export class LiveKitTransport extends Transport {
   }
 
   async updateMic(micId: string): Promise<void> {
+    if ((this._selectedMic as MediaDeviceInfo).deviceId === micId) return;
     try {
       await this._room.switchActiveDevice("audioinput", micId);
       const mics = await this.getAllMics();
@@ -258,6 +227,7 @@ export class LiveKitTransport extends Transport {
   }
 
   async updateCam(camId: string): Promise<void> {
+    if ((this._selectedCam as MediaDeviceInfo).deviceId === camId) return;
     try {
       await this._room.switchActiveDevice("videoinput", camId);
       const cams = await this.getAllCams();
@@ -274,6 +244,8 @@ export class LiveKitTransport extends Transport {
   }
 
   async updateSpeaker(speakerId: string): Promise<void> {
+    if ((this._selectedSpeaker as MediaDeviceInfo).deviceId === speakerId)
+      return;
     try {
       await this._room.switchActiveDevice("audiooutput", speakerId);
       const speakers = await this.getAllSpeakers();
@@ -313,11 +285,14 @@ export class LiveKitTransport extends Transport {
           if (deviceId) {
             const mics = await this.getAllMics();
             const mic = mics.find((m) => m.deviceId === deviceId);
-            if (mic) this._selectedMic = mic;
+            if (
+              mic &&
+              (this._selectedMic as MediaDeviceInfo).deviceId !== mic.deviceId
+            ) {
+              this._selectedMic = mic;
+              this._callbacks.onMicUpdated?.(mic);
+            }
           }
-        }
-        if (this._isMediaDeviceInfo(this._selectedMic)) {
-          this._callbacks.onMicUpdated?.(this._selectedMic);
         }
       })
       .catch((e) => {
@@ -342,11 +317,14 @@ export class LiveKitTransport extends Transport {
           if (deviceId) {
             const cams = await this.getAllCams();
             const cam = cams.find((c) => c.deviceId === deviceId);
-            if (cam) this._selectedCam = cam;
+            if (
+              cam &&
+              (this._selectedCam as MediaDeviceInfo).deviceId !== cam.deviceId
+            ) {
+              this._selectedCam = cam;
+              this._callbacks.onCamUpdated?.(cam);
+            }
           }
-        }
-        if (this._isMediaDeviceInfo(this._selectedCam)) {
-          this._callbacks.onCamUpdated?.(this._selectedCam);
         }
       })
       .catch((e) => {
@@ -355,12 +333,6 @@ export class LiveKitTransport extends Transport {
           new DeviceError(["cam"], "unknown", e.message)
         );
       });
-  }
-
-  private _isMediaDeviceInfo(
-    device: MediaDeviceInfo | Record<string, never>
-  ): device is MediaDeviceInfo {
-    return (device as MediaDeviceInfo).deviceId !== undefined;
   }
 
   get isMicEnabled(): boolean {
@@ -397,7 +369,6 @@ export class LiveKitTransport extends Transport {
       screenAudio: getTrack(local, "audio", Track.Source.ScreenShareAudio),
     };
 
-    // Uses first remote participant as bot; no explicit bot identity API yet.
     const remoteParticipants = Array.from(
       this._room.remoteParticipants.values()
     );
@@ -527,7 +498,6 @@ export class LiveKitTransport extends Transport {
 
   private handleParticipantConnected(participant: RemoteParticipant) {
     this._callbacks.onParticipantJoined?.(this.toParticipant(participant));
-    // Potential bot identification logic here
   }
 
   private handleParticipantDisconnected(participant: RemoteParticipant) {

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -1,7 +1,10 @@
 import {
+  DeviceArray,
   DeviceError,
+  DeviceErrorType,
   Participant,
   PipecatClientOptions,
+  RTVI_MESSAGE_LABEL,
   RTVIMessage,
   Tracks,
   Transport,
@@ -14,6 +17,7 @@ import {
   LocalParticipant,
   LocalTrackPublication,
   LocalVideoTrack,
+  MediaDeviceFailure,
   RemoteParticipant,
   RemoteTrack,
   RemoteTrackPublication,
@@ -164,7 +168,9 @@ export class LiveKitTransport extends Transport {
   async _connect(connectParams?: LiveKitConnectParams): Promise<void> {
     if (!connectParams?.url || !connectParams?.token) {
       this.state = "error";
-      throw new TransportStartError("LiveKit connection requires 'url' and 'token'");
+      throw new TransportStartError(
+        "LiveKit connection requires 'url' and 'token'"
+      );
     }
 
     this.state = "connecting";
@@ -460,7 +466,13 @@ export class LiveKitTransport extends Transport {
       const decoder = new TextDecoder();
       const str = decoder.decode(payload);
       const msg = JSON.parse(str);
-      if (msg && typeof msg === "object" && "type" in msg) {
+      // Only bubble RTVI messages; ignore any other data on the channel.
+      if (
+        msg &&
+        typeof msg === "object" &&
+        "type" in msg &&
+        msg.label === RTVI_MESSAGE_LABEL
+      ) {
         this._onMessage(msg as RTVIMessage);
       }
     } catch (e) {
@@ -502,18 +514,36 @@ export class LiveKitTransport extends Transport {
         this.toParticipant(participant)
       );
     }
+
+    const deviceId =
+      publication.track?.mediaStreamTrack?.getSettings().deviceId;
+    if (!deviceId) return;
+
+    // Sync the selected input device when a capture track is published (e.g.
+    // via setMicrophoneEnabled/setCameraEnabled on the connect-without-
+    // initDevices path). Screen-share sources are not selectable devices.
     if (publication.source === Track.Source.Microphone) {
-      const deviceId =
-        publication.track?.mediaStreamTrack?.getSettings().deviceId;
-      if (deviceId) {
-        this.getAllMics().then((mics) => {
-          const mic = mics.find((m) => m.deviceId === deviceId);
-          if (mic) {
-            this._selectedMic = mic;
-            this._callbacks.onMicUpdated?.(mic);
-          }
-        });
-      }
+      this.getAllMics().then((mics) => {
+        const mic = mics.find((m) => m.deviceId === deviceId);
+        if (
+          mic &&
+          (this._selectedMic as MediaDeviceInfo).deviceId !== deviceId
+        ) {
+          this._selectedMic = mic;
+          this._callbacks.onMicUpdated?.(mic);
+        }
+      });
+    } else if (publication.source === Track.Source.Camera) {
+      this.getAllCams().then((cams) => {
+        const cam = cams.find((c) => c.deviceId === deviceId);
+        if (
+          cam &&
+          (this._selectedCam as MediaDeviceInfo).deviceId !== deviceId
+        ) {
+          this._selectedCam = cam;
+          this._callbacks.onCamUpdated?.(cam);
+        }
+      });
     }
   }
 
@@ -544,10 +574,40 @@ export class LiveKitTransport extends Transport {
     }
   }
 
-  private handleMediaDevicesError(e: Error) {
+  private handleMediaDevicesError(e: Error, kind?: MediaDeviceKind) {
+    const devices: DeviceArray = [];
+    if (kind === "audioinput") devices.push("mic");
+    else if (kind === "videoinput") devices.push("cam");
+    else if (kind === "audiooutput") devices.push("speaker");
+    else {
+      // No kind reported: fall back to LiveKit's last per-device errors to
+      // work out which capture actually failed, defaulting to both.
+      const lp = this._room.localParticipant;
+      if (lp.lastMicrophoneError) devices.push("mic");
+      if (lp.lastCameraError) devices.push("cam");
+      if (devices.length === 0) devices.push("cam", "mic");
+    }
+
     this._callbacks.onDeviceError?.(
-      new DeviceError(["cam", "mic"], "unknown", e.message)
+      new DeviceError(
+        devices,
+        this.toDeviceErrorType(MediaDeviceFailure.getFailure(e)),
+        e.message
+      )
     );
+  }
+
+  private toDeviceErrorType(failure?: MediaDeviceFailure): DeviceErrorType {
+    switch (failure) {
+      case MediaDeviceFailure.PermissionDenied:
+        return "permissions";
+      case MediaDeviceFailure.NotFound:
+        return "not-found";
+      case MediaDeviceFailure.DeviceInUse:
+        return "in-use";
+      default:
+        return "unknown";
+    }
   }
 
   private toParticipant(p: LocalParticipant | RemoteParticipant): Participant {

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -410,45 +410,19 @@ export class LiveKitTransport extends Transport {
       "devicechange",
       this._deviceChangeHandler
     );
+    // room.disconnect() emits RoomEvent.Disconnected synchronously, before
+    // its own promise resolves, *if* the room was actually connected
+    // (confirmed against livekit-client's source — handleDisconnect() runs
+    // and emits in the same synchronous block the await here is waiting on).
+    // handleRoomDisconnected() is what actually tears everything down, for
+    // this explicit path, an involuntary one (network drop, room closed
+    // server-side), and a room that was never connected in the first place
+    // (initDevices() ran, connect() never did — the real SDK no-ops without
+    // emitting anything in that case) — one teardown routine, not two. It's
+    // idempotent (guarded on this.state), so calling it explicitly here too
+    // is a harmless no-op if the event already ran it.
     await this._room.disconnect();
-    // room.disconnect() stops tracks it actually published, but a track
-    // acquired via initDevices()/enableMic()/enableCam() that was never
-    // published (connect() never ran, or failed before Promise.all settled)
-    // is still open — stop it explicitly so the mic/camera indicator doesn't
-    // linger. Safe to call on an already-stopped track (no-op per spec).
-    this._localAudioTrack?.stop();
-    this._localVideoTrack?.stop();
-
-    // Report this the same way enableMic(false)/enableCam(false) would,
-    // rather than just dropping the references below: fire onTrackStopped
-    // for whatever was last live, and flip _mic/camEnabled to false so
-    // isMicEnabled()/isCamEnabled() (and any mute/unmute toggle bound to
-    // them) reflect reality. Without this, disconnect leaves both saying
-    // "enabled" with no track behind them — silently wrong, and still wrong
-    // after a later connect() since nothing re-acquires unless the caller
-    // notices the mismatch and explicitly re-enables.
-    //
-    // Assign _mic/camEnabled *before* firing onTrackStopped below — same
-    // ordering fix as enableMic()/enableCam(): anything reacting to that
-    // event (e.g. client-react resyncing isMicEnabled) reads this same
-    // getter, and needs to see false already, not whatever it was pre-
-    // disconnect.
-    this._micEnabled = false;
-    this._camEnabled = false;
-    const participant = { id: "local", name: "", local: true };
-    if (this._lastReportedMicTrack) {
-      this._callbacks.onTrackStopped?.(this._lastReportedMicTrack, participant);
-    }
-    if (this._lastReportedCamTrack) {
-      this._callbacks.onTrackStopped?.(this._lastReportedCamTrack, participant);
-    }
-    this._localAudioTrack = undefined;
-    this._localVideoTrack = undefined;
-    this._lastReportedMicTrack = undefined;
-    this._lastReportedCamTrack = undefined;
-    this._botId = "";
-    this.state = "disconnected";
-    this._callbacks.onDisconnected?.();
+    this.handleRoomDisconnected();
   }
 
   sendMessage(message: RTVIMessage): void {
@@ -986,12 +960,51 @@ export class LiveKitTransport extends Transport {
     }
   }
 
+  // The single teardown routine for both an explicit _disconnect() and an
+  // involuntary disconnect (network drop, room closed server-side) — see
+  // _disconnect()'s comment for why both funnel through here via
+  // RoomEvent.Disconnected rather than duplicating this logic.
   private handleRoomDisconnected() {
-    this._botId = "";
-    if (this.state !== "disconnected") {
-      this.state = "disconnected";
-      this._callbacks.onDisconnected?.();
+    if (this.state === "disconnected") return;
+
+    // room.disconnect() stops tracks it actually published, but a track
+    // acquired via initDevices()/enableMic()/enableCam() that was never
+    // published (connect() never ran, or failed before Promise.all settled)
+    // is still open — stop it explicitly so the mic/camera indicator doesn't
+    // linger. Safe to call on an already-stopped track (no-op per spec).
+    this._localAudioTrack?.stop();
+    this._localVideoTrack?.stop();
+
+    // Report this the same way enableMic(false)/enableCam(false) would,
+    // rather than just dropping the references below: fire onTrackStopped
+    // for whatever was last live, and flip _mic/camEnabled to false so
+    // isMicEnabled()/isCamEnabled() (and any mute/unmute toggle bound to
+    // them) reflect reality. Without this, disconnect leaves both saying
+    // "enabled" with no track behind them — silently wrong, and still wrong
+    // after a later connect() since nothing re-acquires unless the caller
+    // notices the mismatch and explicitly re-enables.
+    //
+    // Assign _mic/camEnabled *before* firing onTrackStopped below — same
+    // ordering fix as enableMic()/enableCam(): anything reacting to that
+    // event (e.g. client-react resyncing isMicEnabled) reads this same
+    // getter, and needs to see false already, not whatever it was pre-
+    // disconnect.
+    this._micEnabled = false;
+    this._camEnabled = false;
+    const participant = { id: "local", name: "", local: true };
+    if (this._lastReportedMicTrack) {
+      this._callbacks.onTrackStopped?.(this._lastReportedMicTrack, participant);
     }
+    if (this._lastReportedCamTrack) {
+      this._callbacks.onTrackStopped?.(this._lastReportedCamTrack, participant);
+    }
+    this._localAudioTrack = undefined;
+    this._localVideoTrack = undefined;
+    this._lastReportedMicTrack = undefined;
+    this._lastReportedCamTrack = undefined;
+    this._botId = "";
+    this.state = "disconnected";
+    this._callbacks.onDisconnected?.();
   }
 
   private handleMediaDevicesError(e: Error, kind?: MediaDeviceKind) {

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -225,6 +225,13 @@ export class LiveKitTransport extends Transport {
   }
 
   sendMessage(message: RTVIMessage): void {
+    if (
+      !this._room ||
+      (this.state !== "connected" && this.state !== "ready")
+    ) {
+      logger.warn("Cannot send message, not connected");
+      return;
+    }
     const str = JSON.stringify(message);
     const encoder = new TextEncoder();
     const data = encoder.encode(str);

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -13,6 +13,7 @@ import {
   logger,
 } from "@pipecat-ai/client-js";
 import {
+  ConnectionState,
   LocalAudioTrack,
   LocalParticipant,
   LocalTrackPublication,
@@ -27,6 +28,7 @@ import {
   RoomOptions,
   Track,
   createLocalAudioTrack,
+  createLocalTracks,
   createLocalVideoTrack,
 } from "livekit-client";
 import packageJson from "../package.json";
@@ -49,9 +51,17 @@ export class LiveKitTransport extends Transport {
   private _micEnabled: boolean = false;
   private _camEnabled: boolean = false;
   private _listenersAttached: boolean = false;
-  private _deviceChangeHandler = () => this.updateAvailableDevices();
+  private _readyHandler: (() => void) | null = null;
+  private _deviceChangeHandler = () => {
+    void this._handleDeviceChange();
+  };
   private _localAudioTrack?: LocalAudioTrack;
   private _localVideoTrack?: LocalVideoTrack;
+  // The raw MediaStreamTrack last reported to the app via onTrackStarted, if
+  // any — _syncSelectedMic/Cam's own record of "what we last told callers is
+  // live", diffed against current reality to decide what to report next.
+  private _lastReportedMicTrack?: MediaStreamTrack;
+  private _lastReportedCamTrack?: MediaStreamTrack;
   private _botId: string = "";
 
   constructor(options: LiveKitTransportConstructorOptions = {}) {
@@ -89,58 +99,115 @@ export class LiveKitTransport extends Transport {
   async initDevices(): Promise<void> {
     this.state = "initializing";
 
-    if (this._micEnabled) {
+    if (this._micEnabled && this._camEnabled) {
       try {
-        this._localAudioTrack = await createLocalAudioTrack();
-        await this.updateAvailableDevices();
-        const deviceId =
-          this._localAudioTrack.mediaStreamTrack.getSettings().deviceId;
-        const mics = await this.getAllMics();
-        const mic = mics.find((m) => m.deviceId === deviceId);
-        if (mic) {
-          this._selectedMic = mic;
-          this._callbacks.onMicUpdated?.(mic);
-        }
-        this._callbacks.onTrackStarted?.(
-          this._localAudioTrack.mediaStreamTrack,
-          { id: "local", name: "", local: true }
-        );
-      } catch (e) {
-        logger.warn("[LiveKit Transport] Could not initialize mic", e);
-        await this.updateAvailableDevices();
+        // createLocalTracks acquires both in one getUserMedia call, showing a
+        // single combined permission prompt instead of two sequential ones.
+        // A bare string deviceId is shorthand for { ideal } (a soft
+        // preference, silently dropped if unsatisfiable) rather than
+        // { exact } (which throws). We want that here: Chrome resolves
+        // "default" to its virtual default-device alias so getSettings()
+        // reports "default" and reselection stays sticky (see
+        // _reacquireIfMissing), but Firefox/Safari have no such device, and
+        // exact would make initDevices() throw there.
+        const tracks = await createLocalTracks({
+          audio: { deviceId: "default" },
+          video: { deviceId: "default" },
+        });
+        const audioTrack = tracks.find((t) => t.kind === Track.Kind.Audio) as
+          | LocalAudioTrack
+          | undefined;
+        const videoTrack = tracks.find((t) => t.kind === Track.Kind.Video) as
+          | LocalVideoTrack
+          | undefined;
+        if (audioTrack) await this._adoptMicTrack(audioTrack);
+        if (videoTrack) await this._adoptCamTrack(videoTrack);
+      } catch {
+        // createLocalTracks, like getUserMedia, is all-or-nothing — one
+        // device failing fails the whole combined request. Fall back to
+        // acquiring each independently so a single bad device doesn't take
+        // the other down with it, and the error attributes to the right one.
+        await Promise.all([this._acquireMic(), this._acquireCam()]);
       }
+    } else {
+      if (this._micEnabled) await this._acquireMic();
+      if (this._camEnabled) await this._acquireCam();
     }
 
-    if (this._camEnabled) {
-      try {
-        this._localVideoTrack = await createLocalVideoTrack();
-        if (!this._micEnabled) await this.updateAvailableDevices();
-        const deviceId =
-          this._localVideoTrack.mediaStreamTrack.getSettings().deviceId;
-        const cams = await this.getAllCams();
-        const cam = cams.find((c) => c.deviceId === deviceId);
-        if (cam) {
-          this._selectedCam = cam;
-          this._callbacks.onCamUpdated?.(cam);
-        }
-        this._callbacks.onTrackStarted?.(
-          this._localVideoTrack.mediaStreamTrack,
-          { id: "local", name: "", local: true }
-        );
-      } catch (e) {
-        logger.warn("[LiveKit Transport] Could not initialize cam", e);
-        if (!this._micEnabled) await this.updateAvailableDevices();
-      }
-    }
-
-    if (!this._micEnabled && !this._camEnabled) {
-      await this.updateAvailableDevices();
-    }
-
+    await this.updateAvailableDevices();
+    await this._syncSelectedSpeaker();
     this.state = "initialized";
   }
 
-  private async updateAvailableDevices() {
+  // Unlike mic/cam, there's no local track to read a live deviceId off of —
+  // nothing is being played out yet pre-connect. So on init we just reflect
+  // whatever the browser currently considers the default output device,
+  // the same way the browser itself would pick one absent any explicit
+  // switchActiveDevice() call.
+  private async _syncSelectedSpeaker(): Promise<void> {
+    const speakers = await this.getAllSpeakers();
+    // Chrome exposes a virtual "default" audiooutput device; Firefox/Safari
+    // don't — by convention the first device in the list is the default there.
+    const speaker =
+      speakers.find((d) => d.deviceId === "default") ?? speakers[0];
+    if (
+      speaker &&
+      (this._selectedSpeaker as MediaDeviceInfo).deviceId !== speaker.deviceId
+    ) {
+      this._selectedSpeaker = speaker;
+      this._callbacks.onSpeakerUpdated?.(speaker);
+    }
+  }
+
+  private async _acquireMic(): Promise<void> {
+    try {
+      // See the comment in initDevices() re: { deviceId: "default" } — a
+      // soft ideal preference, not exact, so this stays safe on Firefox/Safari.
+      await this._adoptMicTrack(
+        await createLocalAudioTrack({ deviceId: "default" })
+      );
+    } catch (e) {
+      logger.warn("[LiveKit Transport] Could not initialize mic", e);
+      this._callbacks.onDeviceError?.(
+        new DeviceError(
+          ["mic"],
+          this.toDeviceErrorType(MediaDeviceFailure.getFailure(e)),
+          e instanceof Error ? e.message : String(e)
+        )
+      );
+    }
+  }
+
+  private async _acquireCam(): Promise<void> {
+    try {
+      await this._adoptCamTrack(
+        await createLocalVideoTrack({ deviceId: "default" })
+      );
+    } catch (e) {
+      logger.warn("[LiveKit Transport] Could not initialize cam", e);
+      this._callbacks.onDeviceError?.(
+        new DeviceError(
+          ["cam"],
+          this.toDeviceErrorType(MediaDeviceFailure.getFailure(e)),
+          e instanceof Error ? e.message : String(e)
+        )
+      );
+    }
+  }
+
+  private async _adoptMicTrack(track: LocalAudioTrack): Promise<void> {
+    this._localAudioTrack = track;
+    await this._syncSelectedMic(track);
+  }
+
+  private async _adoptCamTrack(track: LocalVideoTrack): Promise<void> {
+    this._localVideoTrack = track;
+    await this._syncSelectedCam(track);
+  }
+
+  private async updateAvailableDevices(): Promise<
+    MediaDeviceInfo[] | undefined
+  > {
     try {
       const devices = await navigator.mediaDevices.enumerateDevices();
       const cams = devices.filter((d) => d.kind === "videoinput");
@@ -150,8 +217,93 @@ export class LiveKitTransport extends Transport {
       this._callbacks.onAvailableCamsUpdated?.(cams);
       this._callbacks.onAvailableMicsUpdated?.(mics);
       this._callbacks.onAvailableSpeakersUpdated?.(speakers);
+      return devices;
     } catch (e) {
       logger.error("Error enumerating devices", e);
+      return undefined;
+    }
+  }
+
+  /**
+   * On devicechange, check whether the mic/cam we're actively capturing from
+   * is still present (or, for a "default" selection, whether the underlying
+   * physical default changed). livekit-client's own Room.selectDefaultDevices
+   * already does this for audiooutput on every devicechange (and switching
+   * the active output there also updates every remote participant's <audio>
+   * element — see updateSpeaker()), but it deliberately skips audioinput
+   * (except a Safari AirPods special case) and videoinput, leaving mic/cam
+   * reselection to us.
+   */
+  private async _handleDeviceChange(): Promise<void> {
+    const devices = await this.updateAvailableDevices();
+    if (!devices) return;
+    await Promise.all([
+      this._reacquireIfMissing(
+        "mic",
+        devices.filter((d) => d.kind === "audioinput")
+      ),
+      this._reacquireIfMissing(
+        "cam",
+        devices.filter((d) => d.kind === "videoinput")
+      ),
+    ]);
+  }
+
+  private async _reacquireIfMissing(
+    kind: "mic" | "cam",
+    devices: MediaDeviceInfo[]
+  ): Promise<void> {
+    const track =
+      kind === "mic" ? this._localAudioTrack : this._localVideoTrack;
+    if (!track) return; // not currently capturing — nothing to reacquire
+
+    const current = (
+      kind === "mic" ? this._selectedMic : this._selectedCam
+    ) as MediaDeviceInfo;
+    if (!current?.deviceId) return;
+
+    // Chrome exposes a virtual "default" device alongside the real ones;
+    // Firefox/Safari don't — by convention the first device in the list is
+    // the default there. Fall back accordingly.
+    const defaultDevice =
+      devices.find((d) => d.deviceId === "default") ?? devices[0];
+    const stillPresent = devices.some((d) => d.deviceId === current.deviceId);
+    const defaultChanged =
+      current.deviceId === "default" && current.label !== defaultDevice?.label;
+    console.log(
+      `[${kind}] reacquire check — current: ${current.deviceId} (${current.label}), stillPresent: ${stillPresent}, defaultDevice: ${defaultDevice?.deviceId} (${defaultDevice?.label}), defaultChanged: ${defaultChanged}`
+    );
+    if (stillPresent && !defaultChanged) return;
+
+    try {
+      if (defaultChanged) {
+        // Re-request the virtual "default" device itself (Chrome-only —
+        // defaultChanged can only be true when current.deviceId is literally
+        // "default"), not just an unconstrained restart. An unconstrained
+        // restartTrack({}) does pick up today's actual default hardware, but
+        // getSettings().deviceId then reports that device's own concrete
+        // hash, not "default" — so _syncSelectedMic/Cam would pin us to that
+        // one device and we'd lose "always follow the default" for the
+        // *next* devicechange. Explicitly requesting { exact: "default" }
+        // keeps getSettings().deviceId reporting "default" going forward.
+        await track.restartTrack({ deviceId: { exact: "default" } });
+      } else {
+        // The selected device physically disappeared. No deviceId
+        // constraint (an empty object, not undefined — restartTrack falls
+        // back to the track's *previous* constraints when passed nothing)
+        // so the browser picks a fresh default.
+        await track.restartTrack({});
+      }
+      if (kind === "mic") await this._syncSelectedMic(track as LocalAudioTrack);
+      else await this._syncSelectedCam(track as LocalVideoTrack);
+    } catch (e) {
+      this._callbacks.onDeviceError?.(
+        new DeviceError(
+          [kind],
+          this.toDeviceErrorType(MediaDeviceFailure.getFailure(e)),
+          e instanceof Error ? e.message : String(e)
+        )
+      );
     }
   }
 
@@ -176,29 +328,69 @@ export class LiveKitTransport extends Transport {
 
     this.state = "connecting";
 
-    try {
-      await this._room.connect(
-        connectParams.url,
-        connectParams.token,
-        connectParams.roomConnectionOptions
+    // Publish alongside connect(), not after it. publishTrack() only waits on
+    // the signal (WebSocket) connection, not full ICE/PC negotiation — the
+    // AddTrackRequest rides in the same initial offer/answer that's already
+    // negotiating for connect(). Sequencing it after connect() resolves would
+    // pay a slow link's cost twice (a full second renegotiation for the
+    // track) instead of once.
+    //
+    // room.connect() failing is a real connection failure. A publish failing
+    // is not — the session can still work with one fewer track — so each
+    // publish gets its own catch that reports onDeviceError (correctly
+    // attributed to mic vs cam) instead of rejecting the whole connect.
+    const roomConnectPromise = this._room.connect(
+      connectParams.url,
+      connectParams.token,
+      connectParams.roomConnectionOptions
+    );
+
+    const publishPromises: Promise<unknown>[] = [];
+    if (this._localAudioTrack) {
+      publishPromises.push(
+        this._room.localParticipant
+          .publishTrack(this._localAudioTrack)
+          .catch((e) => {
+            logger.error("[LiveKit Transport] Failed to publish mic track", e);
+            this._callbacks.onDeviceError?.(
+              new DeviceError(
+                ["mic"],
+                "unknown",
+                e instanceof Error ? e.message : String(e)
+              )
+            );
+          })
       );
+    }
+    if (this._localVideoTrack) {
+      publishPromises.push(
+        this._room.localParticipant
+          .publishTrack(this._localVideoTrack)
+          .catch((e) => {
+            logger.error("[LiveKit Transport] Failed to publish cam track", e);
+            this._callbacks.onDeviceError?.(
+              new DeviceError(
+                ["cam"],
+                "unknown",
+                e instanceof Error ? e.message : String(e)
+              )
+            );
+          })
+      );
+    }
+
+    try {
+      await roomConnectPromise;
     } catch (e) {
       logger.error("Failed to connect to LiveKit room", e);
       this.state = "error";
       throw new TransportStartError();
     }
 
-    if (this._localAudioTrack) {
-      await this._room.localParticipant.publishTrack(this._localAudioTrack);
-    } else if (this._micEnabled) {
-      await this._room.localParticipant.setMicrophoneEnabled(true);
-    }
-
-    if (this._localVideoTrack) {
-      await this._room.localParticipant.publishTrack(this._localVideoTrack);
-    } else if (this._camEnabled) {
-      await this._room.localParticipant.setCameraEnabled(true);
-    }
+    // Publishes were kicked off alongside connect() above; their failures are
+    // already caught and reported, so this can't reject — just makes sure
+    // they've settled before we consider ourselves connected.
+    await Promise.all(publishPromises);
 
     // room.connect() and the publish awaits above are all points at which a
     // concurrent disconnect() may have aborted us and already set state to
@@ -219,18 +411,24 @@ export class LiveKitTransport extends Transport {
       this._deviceChangeHandler
     );
     await this._room.disconnect();
+    // room.disconnect() stops tracks it actually published, but a track
+    // acquired via initDevices()/enableMic()/enableCam() that was never
+    // published (connect() never ran, or failed before Promise.all settled)
+    // is still open — stop it explicitly so the mic/camera indicator doesn't
+    // linger. Safe to call on an already-stopped track (no-op per spec).
+    this._localAudioTrack?.stop();
+    this._localVideoTrack?.stop();
     this._localAudioTrack = undefined;
     this._localVideoTrack = undefined;
+    this._lastReportedMicTrack = undefined;
+    this._lastReportedCamTrack = undefined;
     this._botId = "";
     this.state = "disconnected";
     this._callbacks.onDisconnected?.();
   }
 
   sendMessage(message: RTVIMessage): void {
-    if (
-      !this._room ||
-      (this.state !== "connected" && this.state !== "ready")
-    ) {
+    if (!this._room || (this.state !== "connected" && this.state !== "ready")) {
       logger.warn("Cannot send message, not connected");
       return;
     }
@@ -257,40 +455,60 @@ export class LiveKitTransport extends Transport {
     return devices.filter((d) => d.kind === "audiooutput");
   }
 
+  // updateMic/updateCam switch the device on our own owned LocalAudioTrack/
+  // LocalVideoTrack via restartTrack() — this works whether or not the track
+  // is currently published (Room-agnostic re-acquire pre-connect; a smooth
+  // sender.replaceTrack() with no renegotiation once published). There's
+  // nothing to switch if the device was never enabled in the first place.
   async updateMic(micId: string): Promise<void> {
     if ((this._selectedMic as MediaDeviceInfo).deviceId === micId) return;
+    if (!this._localAudioTrack) return;
+    const track = this._localAudioTrack;
     try {
-      await this._room.switchActiveDevice("audioinput", micId);
-      const mics = await this.getAllMics();
-      const mic = mics.find((m) => m.deviceId === micId);
-      if (mic) {
-        this._selectedMic = mic;
-        this._callbacks.onMicUpdated?.(mic);
-      }
-    } catch (e: unknown) {
+      const id_before = track.mediaStreamTrack.getSettings().deviceId;
+      console.log(`Updating mic from ${id_before} to ${micId}`);
+      // A bare string deviceId is shorthand for { ideal: micId } — a soft
+      // preference the browser can (and in practice does) ignore in favor of
+      // whatever device is already active. { exact } forces the switch,
+      // matching what Room.switchActiveDevice does for exactly this reason.
+      await track.restartTrack({ deviceId: { exact: micId } });
+      console.log(
+        `Mic id after restartTrack: ${track.mediaStreamTrack.getSettings().deviceId}`
+      );
+      await this._syncSelectedMic(track);
+    } catch (e) {
       this._callbacks.onDeviceError?.(
-        new DeviceError(["mic"], "unknown", (e as Error).message)
+        new DeviceError(
+          ["mic"],
+          this.toDeviceErrorType(MediaDeviceFailure.getFailure(e)),
+          e instanceof Error ? e.message : String(e)
+        )
       );
     }
   }
 
   async updateCam(camId: string): Promise<void> {
     if ((this._selectedCam as MediaDeviceInfo).deviceId === camId) return;
+    if (!this._localVideoTrack) return;
+    const track = this._localVideoTrack;
     try {
-      await this._room.switchActiveDevice("videoinput", camId);
-      const cams = await this.getAllCams();
-      const cam = cams.find((c) => c.deviceId === camId);
-      if (cam) {
-        this._selectedCam = cam;
-        this._callbacks.onCamUpdated?.(cam);
-      }
-    } catch (e: unknown) {
+      await track.restartTrack({ deviceId: { exact: camId } });
+      await this._syncSelectedCam(track);
+    } catch (e) {
       this._callbacks.onDeviceError?.(
-        new DeviceError(["cam"], "unknown", (e as Error).message)
+        new DeviceError(
+          ["cam"],
+          this.toDeviceErrorType(MediaDeviceFailure.getFailure(e)),
+          e instanceof Error ? e.message : String(e)
+        )
       );
     }
   }
 
+  // room.switchActiveDevice("audiooutput", ...) already updates the sinkId on
+  // every remote participant's <audio> element internally (Room.ts calls
+  // participant.setAudioOutput() for each one) — the DOM-walking LiveKit does
+  // itself isn't something we need to replicate here.
   async updateSpeaker(speakerId: string): Promise<void> {
     if ((this._selectedSpeaker as MediaDeviceInfo).deviceId === speakerId)
       return;
@@ -319,68 +537,167 @@ export class LiveKitTransport extends Transport {
     return this._selectedSpeaker;
   }
 
-  enableMic(enable: boolean): void {
-    this._room.localParticipant
-      .setMicrophoneEnabled(enable)
-      .then(async () => {
-        this._micEnabled = enable;
-        if (enable) {
-          const trackPub = this._room.localParticipant.getTrackPublication(
+  // Gate on livekit-client's own Room state (not our TransportState) since
+  // that's what determines which API applies: setMicrophoneEnabled()
+  // depends on an active engine connection, createLocalAudioTrack() doesn't.
+  //
+  // When connected, always go through setMicrophoneEnabled() rather than
+  // branching on whether we already hold a track ourselves — that's exactly
+  // what it does internally (livekit-client's own setTrackEnabled() calls
+  // track.mute()/unmute() when a publication already exists, or creates +
+  // publishes a fresh one otherwise), so there's no reason to duplicate that
+  // decision on our end. Either way, _syncSelectedMic() afterwards figures
+  // out what actually changed and reports it.
+  async enableMic(enable: boolean): Promise<void> {
+    try {
+      const existingTrack = this._localAudioTrack;
+
+      if (this._room.state === ConnectionState.Connected) {
+        await this._room.localParticipant.setMicrophoneEnabled(enable);
+        if (existingTrack) {
+          await this._syncSelectedMic(existingTrack);
+        } else if (enable) {
+          const pub = this._room.localParticipant.getTrackPublication(
             Track.Source.Microphone
           );
-          const deviceId =
-            trackPub?.track?.mediaStreamTrack?.getSettings().deviceId;
-          if (deviceId) {
-            const mics = await this.getAllMics();
-            const mic = mics.find((m) => m.deviceId === deviceId);
-            if (
-              mic &&
-              (this._selectedMic as MediaDeviceInfo).deviceId !== mic.deviceId
-            ) {
-              this._selectedMic = mic;
-              this._callbacks.onMicUpdated?.(mic);
-            }
-          }
+          if (pub?.track)
+            await this._adoptMicTrack(pub.track as LocalAudioTrack);
         }
-      })
-      .catch((e) => {
-        logger.error("Failed to toggle mic", e);
-        this._callbacks.onDeviceError?.(
-          new DeviceError(["mic"], "unknown", e.message)
-        );
-      });
+      } else if (existingTrack) {
+        // Not connected: manage our own Room-agnostic pre-warmed track
+        // directly — there's no engine connection for setMicrophoneEnabled()
+        // to depend on yet.
+        if (enable) await existingTrack.unmute();
+        else await existingTrack.mute();
+        await this._syncSelectedMic(existingTrack);
+      } else if (enable) {
+        await this._adoptMicTrack(await createLocalAudioTrack());
+      }
+
+      // Set only once the requested state is actually in effect — a failed
+      // attempt (caught below) leaves this reflecting reality instead of
+      // the intent we merely attempted.
+      this._micEnabled = enable;
+    } catch (e) {
+      logger.error("Failed to toggle mic", e);
+      this._callbacks.onDeviceError?.(
+        new DeviceError(
+          ["mic"],
+          this.toDeviceErrorType(MediaDeviceFailure.getFailure(e)),
+          e instanceof Error ? e.message : String(e)
+        )
+      );
+    }
   }
 
-  enableCam(enable: boolean): void {
-    this._room.localParticipant
-      .setCameraEnabled(enable)
-      .then(async () => {
-        this._camEnabled = enable;
-        if (enable) {
-          const trackPub = this._room.localParticipant.getTrackPublication(
+  // Same shape as enableMic(); see its comment for the setCameraEnabled()/
+  // mute()/unmute() split.
+  async enableCam(enable: boolean): Promise<void> {
+    try {
+      const existingTrack = this._localVideoTrack;
+
+      if (this._room.state === ConnectionState.Connected) {
+        await this._room.localParticipant.setCameraEnabled(enable);
+        if (existingTrack) {
+          await this._syncSelectedCam(existingTrack);
+        } else if (enable) {
+          const pub = this._room.localParticipant.getTrackPublication(
             Track.Source.Camera
           );
-          const deviceId =
-            trackPub?.track?.mediaStreamTrack?.getSettings().deviceId;
-          if (deviceId) {
-            const cams = await this.getAllCams();
-            const cam = cams.find((c) => c.deviceId === deviceId);
-            if (
-              cam &&
-              (this._selectedCam as MediaDeviceInfo).deviceId !== cam.deviceId
-            ) {
-              this._selectedCam = cam;
-              this._callbacks.onCamUpdated?.(cam);
-            }
-          }
+          if (pub?.track)
+            await this._adoptCamTrack(pub.track as LocalVideoTrack);
         }
-      })
-      .catch((e) => {
-        logger.error("Failed to toggle cam", e);
-        this._callbacks.onDeviceError?.(
-          new DeviceError(["cam"], "unknown", e.message)
+      } else if (existingTrack) {
+        if (enable) await existingTrack.unmute();
+        else await existingTrack.mute();
+        await this._syncSelectedCam(existingTrack);
+      } else if (enable) {
+        await this._adoptCamTrack(await createLocalVideoTrack());
+      }
+
+      // See enableMic()'s comment: only set once the requested state is
+      // actually in effect.
+      this._camEnabled = enable;
+    } catch (e) {
+      logger.error("Failed to toggle cam", e);
+      this._callbacks.onDeviceError?.(
+        new DeviceError(
+          ["cam"],
+          this.toDeviceErrorType(MediaDeviceFailure.getFailure(e)),
+          e instanceof Error ? e.message : String(e)
+        )
+      );
+    }
+  }
+
+  // Single entry point for "something about the mic/cam track may have
+  // changed" — called after every acquire, mute/unmute, restart (device
+  // switch or devicechange-driven reselect), and setMicrophoneEnabled()/
+  // setCameraEnabled(). Figures out what actually changed by diffing against
+  // last-known state, rather than making each call site work that out:
+  //   - device: compares against _selectedMic/_selectedCam, fires
+  //     onMicUpdated/onCamUpdated if the resolved device differs.
+  //   - validity: compares the current "live" raw track (undefined while
+  //     muted) against the last one we reported via onTrackStarted, firing
+  //     onTrackStopped/onTrackStarted for whatever actually differs. This
+  //     covers every case uniformly: a fresh acquire (nothing → track), a
+  //     mute (track → nothing), an unmute (nothing → track, same or restarted
+  //     object), a device switch (track → different track), and a no-op
+  //     repeat call (nothing to report either way).
+  private async _syncSelectedMic(track: LocalAudioTrack): Promise<void> {
+    const deviceId = track.mediaStreamTrack.getSettings().deviceId;
+    const mics = await this.getAllMics();
+    const mic = mics.find((m) => m.deviceId === deviceId);
+    if (
+      mic &&
+      (this._selectedMic as MediaDeviceInfo).deviceId !== mic.deviceId
+    ) {
+      this._selectedMic = mic;
+      this._callbacks.onMicUpdated?.(mic);
+    }
+
+    const liveTrack = track.isMuted ? undefined : track.mediaStreamTrack;
+    if (liveTrack !== this._lastReportedMicTrack) {
+      const participant = { id: "local", name: "", local: true };
+      if (this._lastReportedMicTrack) {
+        this._callbacks.onTrackStopped?.(
+          this._lastReportedMicTrack,
+          participant
         );
-      });
+      }
+      if (liveTrack) {
+        this._callbacks.onTrackStarted?.(liveTrack, participant);
+      }
+      this._lastReportedMicTrack = liveTrack;
+    }
+  }
+
+  private async _syncSelectedCam(track: LocalVideoTrack): Promise<void> {
+    const deviceId = track.mediaStreamTrack.getSettings().deviceId;
+    const cams = await this.getAllCams();
+    const cam = cams.find((c) => c.deviceId === deviceId);
+    if (
+      cam &&
+      (this._selectedCam as MediaDeviceInfo).deviceId !== cam.deviceId
+    ) {
+      this._selectedCam = cam;
+      this._callbacks.onCamUpdated?.(cam);
+    }
+
+    const liveTrack = track.isMuted ? undefined : track.mediaStreamTrack;
+    if (liveTrack !== this._lastReportedCamTrack) {
+      const participant = { id: "local", name: "", local: true };
+      if (this._lastReportedCamTrack) {
+        this._callbacks.onTrackStopped?.(
+          this._lastReportedCamTrack,
+          participant
+        );
+      }
+      if (liveTrack) {
+        this._callbacks.onTrackStarted?.(liveTrack, participant);
+      }
+      this._lastReportedCamTrack = liveTrack;
+    }
   }
 
   get isMicEnabled(): boolean {
@@ -403,18 +720,17 @@ export class LiveKitTransport extends Transport {
     const local = this._room.localParticipant;
     const getTrack = (
       p: LocalParticipant | RemoteParticipant,
-      _kind: string,
       source: Track.Source
-    ) => {
-      const pub = p.getTrackPublication(source);
-      return pub?.track?.mediaStreamTrack;
-    };
+    ) => p.getTrackPublication(source)?.track?.mediaStreamTrack;
 
+    // Mic/cam come straight from our own track references — reflects reality
+    // even pre-connect (e.g. right after initDevices()/enableMic(), before
+    // _connect() has published anything). Screen share is still LiveKit-native.
     const localTracks = {
-      audio: getTrack(local, "audio", Track.Source.Microphone),
-      video: getTrack(local, "video", Track.Source.Camera),
-      screenVideo: getTrack(local, "video", Track.Source.ScreenShare),
-      screenAudio: getTrack(local, "audio", Track.Source.ScreenShareAudio),
+      audio: this._localAudioTrack?.mediaStreamTrack,
+      video: this._localVideoTrack?.mediaStreamTrack,
+      screenVideo: getTrack(local, Track.Source.ScreenShare),
+      screenAudio: getTrack(local, Track.Source.ScreenShareAudio),
     };
 
     const botParticipant = this._botId
@@ -422,8 +738,8 @@ export class LiveKitTransport extends Transport {
       : undefined;
     const botTracks = botParticipant
       ? {
-          audio: getTrack(botParticipant, "audio", Track.Source.Microphone),
-          video: getTrack(botParticipant, "video", Track.Source.Camera),
+          audio: getTrack(botParticipant, Track.Source.Microphone),
+          video: getTrack(botParticipant, Track.Source.Camera),
         }
       : {};
 
@@ -431,9 +747,34 @@ export class LiveKitTransport extends Transport {
   }
 
   async sendReadyMessage() {
-    this.state = "ready";
-    await this._room.localParticipant.waitUntilActive();
-    this.sendMessage(RTVIMessage.clientReady());
+    return new Promise<void>((resolve) => {
+      // "ready" means the bot can hear/see us and we can hear/see it, not
+      // just "connected to the room" — so only resolve immediately if the
+      // bot's mic or cam track is already subscribed; otherwise wait for
+      // handleTrackSubscribed below.
+      const botParticipant = this._botId
+        ? this._room.remoteParticipants.get(this._botId)
+        : undefined;
+      const hasBotMedia =
+        !!botParticipant?.getTrackPublication(Track.Source.Microphone)
+          ?.track ||
+        !!botParticipant?.getTrackPublication(Track.Source.Camera)?.track;
+
+      if (hasBotMedia) {
+        this.state = "ready";
+        this.sendMessage(RTVIMessage.clientReady());
+        resolve();
+        return;
+      }
+
+      const readyHandler = () => {
+        this.state = "ready";
+        this.sendMessage(RTVIMessage.clientReady());
+        resolve();
+        this._readyHandler = null;
+      };
+      this._readyHandler = readyHandler;
+    }); // End of Promise
   }
 
   private attachEventListeners() {
@@ -493,10 +834,29 @@ export class LiveKitTransport extends Transport {
     publication: RemoteTrackPublication,
     participant: RemoteParticipant
   ) {
-    this._callbacks.onTrackStarted?.(
-      track.mediaStreamTrack,
-      this.toParticipant(participant)
+    console.log(
+      "track subscribed",
+      track.kind,
+      publication.source,
+      participant.identity
     );
+    if (this._readyHandler) {
+      this._readyHandler();
+    }
+    const isScreenShare =
+      publication.source === Track.Source.ScreenShare ||
+      publication.source === Track.Source.ScreenShareAudio;
+    if (isScreenShare) {
+      this._callbacks.onScreenTrackStarted?.(
+        track.mediaStreamTrack,
+        this.toParticipant(participant)
+      );
+    } else {
+      this._callbacks.onTrackStarted?.(
+        track.mediaStreamTrack,
+        this.toParticipant(participant)
+      );
+    }
   }
 
   private handleTrackUnsubscribed(
@@ -504,7 +864,16 @@ export class LiveKitTransport extends Transport {
     publication: RemoteTrackPublication,
     participant: RemoteParticipant
   ) {
-    if (track.mediaStreamTrack) {
+    if (!track.mediaStreamTrack) return;
+    const isScreenShare =
+      publication.source === Track.Source.ScreenShare ||
+      publication.source === Track.Source.ScreenShareAudio;
+    if (isScreenShare) {
+      this._callbacks.onScreenTrackStopped?.(
+        track.mediaStreamTrack,
+        this.toParticipant(participant)
+      );
+    } else {
       this._callbacks.onTrackStopped?.(
         track.mediaStreamTrack,
         this.toParticipant(participant)
@@ -512,46 +881,29 @@ export class LiveKitTransport extends Transport {
     }
   }
 
+  // Mic/cam publish/unpublish and device-sync are driven explicitly by
+  // initDevices()/enableMic()/enableCam()/updateMic()/updateCam() against our
+  // own owned LocalAudioTrack/LocalVideoTrack now — reporting them again here
+  // off the room's own publish event would double-fire onTrackStarted/
+  // onMicUpdated/onCamUpdated. Screen share is still LiveKit-native
+  // (setScreenShareEnabled), so it's the only source reported from these
+  // room-level events — via onScreenTrackStarted/Stopped, not the generic
+  // onTrackStarted/Stopped (those are for mic/cam/remote tracks).
   private handleLocalTrackPublished(
     publication: LocalTrackPublication,
     participant: LocalParticipant
   ) {
+    if (
+      publication.source !== Track.Source.ScreenShare &&
+      publication.source !== Track.Source.ScreenShareAudio
+    ) {
+      return;
+    }
     if (publication.track?.mediaStreamTrack) {
-      this._callbacks.onTrackStarted?.(
+      this._callbacks.onScreenTrackStarted?.(
         publication.track.mediaStreamTrack,
         this.toParticipant(participant)
       );
-    }
-
-    const deviceId =
-      publication.track?.mediaStreamTrack?.getSettings().deviceId;
-    if (!deviceId) return;
-
-    // Sync the selected input device when a capture track is published (e.g.
-    // via setMicrophoneEnabled/setCameraEnabled on the connect-without-
-    // initDevices path). Screen-share sources are not selectable devices.
-    if (publication.source === Track.Source.Microphone) {
-      this.getAllMics().then((mics) => {
-        const mic = mics.find((m) => m.deviceId === deviceId);
-        if (
-          mic &&
-          (this._selectedMic as MediaDeviceInfo).deviceId !== deviceId
-        ) {
-          this._selectedMic = mic;
-          this._callbacks.onMicUpdated?.(mic);
-        }
-      });
-    } else if (publication.source === Track.Source.Camera) {
-      this.getAllCams().then((cams) => {
-        const cam = cams.find((c) => c.deviceId === deviceId);
-        if (
-          cam &&
-          (this._selectedCam as MediaDeviceInfo).deviceId !== deviceId
-        ) {
-          this._selectedCam = cam;
-          this._callbacks.onCamUpdated?.(cam);
-        }
-      });
     }
   }
 
@@ -559,8 +911,14 @@ export class LiveKitTransport extends Transport {
     publication: LocalTrackPublication,
     participant: LocalParticipant
   ) {
+    if (
+      publication.source !== Track.Source.ScreenShare &&
+      publication.source !== Track.Source.ScreenShareAudio
+    ) {
+      return;
+    }
     if (publication.track?.mediaStreamTrack) {
-      this._callbacks.onTrackStopped?.(
+      this._callbacks.onScreenTrackStopped?.(
         publication.track.mediaStreamTrack,
         this.toParticipant(participant)
       );
@@ -568,6 +926,7 @@ export class LiveKitTransport extends Transport {
   }
 
   private handleParticipantConnected(participant: RemoteParticipant) {
+    console.log("participant joined", participant.identity, participant.name);
     this._callbacks.onParticipantJoined?.(this.toParticipant(participant));
 
     // Mirrors the other transports: the first remote participant to join is

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -10,8 +10,10 @@ import {
   logger,
 } from "@pipecat-ai/client-js";
 import {
+  LocalAudioTrack,
   LocalParticipant,
   LocalTrackPublication,
+  LocalVideoTrack,
   RemoteParticipant,
   RemoteTrack,
   RemoteTrackPublication,
@@ -20,6 +22,8 @@ import {
   RoomEvent,
   RoomOptions,
   Track,
+  createLocalAudioTrack,
+  createLocalVideoTrack,
 } from "livekit-client";
 import packageJson from "../package.json";
 
@@ -42,6 +46,8 @@ export class LiveKitTransport extends Transport {
   private _camEnabled: boolean = false;
   private _listenersAttached: boolean = false;
   private _deviceChangeHandler = () => this.updateAvailableDevices();
+  private _localAudioTrack?: LocalAudioTrack;
+  private _localVideoTrack?: LocalVideoTrack;
 
   constructor(options: LiveKitTransportConstructorOptions = {}) {
     super();
@@ -78,43 +84,51 @@ export class LiveKitTransport extends Transport {
   async initDevices(): Promise<void> {
     this.state = "initializing";
 
-    if (this._micEnabled || this._camEnabled) {
+    if (this._micEnabled) {
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({
-          audio: this._micEnabled,
-          video: this._camEnabled,
-        });
-
+        this._localAudioTrack = await createLocalAudioTrack();
         await this.updateAvailableDevices();
-
-        const audioTrack = stream.getAudioTracks()[0];
-        if (audioTrack) {
-          const deviceId = audioTrack.getSettings().deviceId;
-          const mics = await this.getAllMics();
-          const mic = mics.find((m) => m.deviceId === deviceId);
-          if (mic) {
-            this._selectedMic = mic;
-            this._callbacks.onMicUpdated?.(mic);
-          }
-          audioTrack.stop();
+        const deviceId =
+          this._localAudioTrack.mediaStreamTrack.getSettings().deviceId;
+        const mics = await this.getAllMics();
+        const mic = mics.find((m) => m.deviceId === deviceId);
+        if (mic) {
+          this._selectedMic = mic;
+          this._callbacks.onMicUpdated?.(mic);
         }
-
-        const videoTrack = stream.getVideoTracks()[0];
-        if (videoTrack) {
-          const deviceId = videoTrack.getSettings().deviceId;
-          const cams = await this.getAllCams();
-          const cam = cams.find((c) => c.deviceId === deviceId);
-          if (cam) {
-            this._selectedCam = cam;
-            this._callbacks.onCamUpdated?.(cam);
-          }
-          videoTrack.stop();
-        }
+        this._callbacks.onTrackStarted?.(
+          this._localAudioTrack.mediaStreamTrack,
+          { id: "local", name: "", local: true }
+        );
       } catch (e) {
-        logger.warn("[LiveKit Transport] Could not initialize devices", e);
+        logger.warn("[LiveKit Transport] Could not initialize mic", e);
         await this.updateAvailableDevices();
       }
-    } else {
+    }
+
+    if (this._camEnabled) {
+      try {
+        this._localVideoTrack = await createLocalVideoTrack();
+        if (!this._micEnabled) await this.updateAvailableDevices();
+        const deviceId =
+          this._localVideoTrack.mediaStreamTrack.getSettings().deviceId;
+        const cams = await this.getAllCams();
+        const cam = cams.find((c) => c.deviceId === deviceId);
+        if (cam) {
+          this._selectedCam = cam;
+          this._callbacks.onCamUpdated?.(cam);
+        }
+        this._callbacks.onTrackStarted?.(
+          this._localVideoTrack.mediaStreamTrack,
+          { id: "local", name: "", local: true }
+        );
+      } catch (e) {
+        logger.warn("[LiveKit Transport] Could not initialize cam", e);
+        if (!this._micEnabled) await this.updateAvailableDevices();
+      }
+    }
+
+    if (!this._micEnabled && !this._camEnabled) {
       await this.updateAvailableDevices();
     }
 
@@ -167,8 +181,19 @@ export class LiveKitTransport extends Transport {
       throw new TransportStartError();
     }
 
-    await this._room.localParticipant.setMicrophoneEnabled(this._micEnabled);
-    await this._room.localParticipant.setCameraEnabled(this._camEnabled);
+    if (this._abortController?.signal.aborted) return;
+
+    if (this._localAudioTrack) {
+      await this._room.localParticipant.publishTrack(this._localAudioTrack);
+    } else if (this._micEnabled) {
+      await this._room.localParticipant.setMicrophoneEnabled(true);
+    }
+
+    if (this._localVideoTrack) {
+      await this._room.localParticipant.publishTrack(this._localVideoTrack);
+    } else if (this._camEnabled) {
+      await this._room.localParticipant.setCameraEnabled(true);
+    }
 
     this.state = "connected";
     this._callbacks.onConnected?.();
@@ -181,6 +206,8 @@ export class LiveKitTransport extends Transport {
       this._deviceChangeHandler
     );
     await this._room.disconnect();
+    this._localAudioTrack = undefined;
+    this._localVideoTrack = undefined;
     this.state = "disconnected";
     this._callbacks.onDisconnected?.();
   }

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -418,6 +418,30 @@ export class LiveKitTransport extends Transport {
     // linger. Safe to call on an already-stopped track (no-op per spec).
     this._localAudioTrack?.stop();
     this._localVideoTrack?.stop();
+
+    // Report this the same way enableMic(false)/enableCam(false) would,
+    // rather than just dropping the references below: fire onTrackStopped
+    // for whatever was last live, and flip _mic/camEnabled to false so
+    // isMicEnabled()/isCamEnabled() (and any mute/unmute toggle bound to
+    // them) reflect reality. Without this, disconnect leaves both saying
+    // "enabled" with no track behind them — silently wrong, and still wrong
+    // after a later connect() since nothing re-acquires unless the caller
+    // notices the mismatch and explicitly re-enables.
+    //
+    // Assign _mic/camEnabled *before* firing onTrackStopped below — same
+    // ordering fix as enableMic()/enableCam(): anything reacting to that
+    // event (e.g. client-react resyncing isMicEnabled) reads this same
+    // getter, and needs to see false already, not whatever it was pre-
+    // disconnect.
+    this._micEnabled = false;
+    this._camEnabled = false;
+    const participant = { id: "local", name: "", local: true };
+    if (this._lastReportedMicTrack) {
+      this._callbacks.onTrackStopped?.(this._lastReportedMicTrack, participant);
+    }
+    if (this._lastReportedCamTrack) {
+      this._callbacks.onTrackStopped?.(this._lastReportedCamTrack, participant);
+    }
     this._localAudioTrack = undefined;
     this._localVideoTrack = undefined;
     this._lastReportedMicTrack = undefined;
@@ -554,6 +578,14 @@ export class LiveKitTransport extends Transport {
 
       if (this._room.state === ConnectionState.Connected) {
         await this._room.localParticipant.setMicrophoneEnabled(enable);
+        // Set right after the real (fallible) operation succeeds, but
+        // *before* _syncSelectedMic/_adoptMicTrack below fire
+        // onTrackStarted/Stopped — consumers reacting to that event (e.g.
+        // client-react's isMicEnabled resync) read this same getter, and
+        // need to see the new value, not whatever it was before this call.
+        // Still only reached on success: a thrown error skips straight to
+        // the catch below, leaving this reflecting reality.
+        this._micEnabled = enable;
         if (existingTrack) {
           await this._syncSelectedMic(existingTrack);
         } else if (enable) {
@@ -569,15 +601,17 @@ export class LiveKitTransport extends Transport {
         // to depend on yet.
         if (enable) await existingTrack.unmute();
         else await existingTrack.mute();
+        this._micEnabled = enable;
         await this._syncSelectedMic(existingTrack);
       } else if (enable) {
-        await this._adoptMicTrack(await createLocalAudioTrack());
+        const track = await createLocalAudioTrack();
+        this._micEnabled = enable;
+        await this._adoptMicTrack(track);
+      } else {
+        // Disabling with nothing currently capturing — no fallible
+        // operation to gate on, just record the (already-true) reality.
+        this._micEnabled = enable;
       }
-
-      // Set only once the requested state is actually in effect — a failed
-      // attempt (caught below) leaves this reflecting reality instead of
-      // the intent we merely attempted.
-      this._micEnabled = enable;
     } catch (e) {
       logger.error("Failed to toggle mic", e);
       this._callbacks.onDeviceError?.(
@@ -598,6 +632,10 @@ export class LiveKitTransport extends Transport {
 
       if (this._room.state === ConnectionState.Connected) {
         await this._room.localParticipant.setCameraEnabled(enable);
+        // See enableMic()'s comment: set before _syncSelectedCam/
+        // _adoptCamTrack below fire onTrackStarted/Stopped, so anything
+        // reacting to that event sees the new value.
+        this._camEnabled = enable;
         if (existingTrack) {
           await this._syncSelectedCam(existingTrack);
         } else if (enable) {
@@ -610,14 +648,17 @@ export class LiveKitTransport extends Transport {
       } else if (existingTrack) {
         if (enable) await existingTrack.unmute();
         else await existingTrack.mute();
+        this._camEnabled = enable;
         await this._syncSelectedCam(existingTrack);
       } else if (enable) {
-        await this._adoptCamTrack(await createLocalVideoTrack());
+        const track = await createLocalVideoTrack();
+        this._camEnabled = enable;
+        await this._adoptCamTrack(track);
+      } else {
+        // Disabling with nothing currently capturing — no fallible
+        // operation to gate on, just record the (already-true) reality.
+        this._camEnabled = enable;
       }
-
-      // See enableMic()'s comment: only set once the requested state is
-      // actually in effect.
-      this._camEnabled = enable;
     } catch (e) {
       logger.error("Failed to toggle cam", e);
       this._callbacks.onDeviceError?.(
@@ -756,8 +797,7 @@ export class LiveKitTransport extends Transport {
         ? this._room.remoteParticipants.get(this._botId)
         : undefined;
       const hasBotMedia =
-        !!botParticipant?.getTrackPublication(Track.Source.Microphone)
-          ?.track ||
+        !!botParticipant?.getTrackPublication(Track.Source.Microphone)?.track ||
         !!botParticipant?.getTrackPublication(Track.Source.Camera)?.track;
 
       if (hasBotMedia) {

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -52,6 +52,7 @@ export class LiveKitTransport extends Transport {
   private _deviceChangeHandler = () => this.updateAvailableDevices();
   private _localAudioTrack?: LocalAudioTrack;
   private _localVideoTrack?: LocalVideoTrack;
+  private _botId: string = "";
 
   constructor(options: LiveKitTransportConstructorOptions = {}) {
     super();
@@ -220,6 +221,7 @@ export class LiveKitTransport extends Transport {
     await this._room.disconnect();
     this._localAudioTrack = undefined;
     this._localVideoTrack = undefined;
+    this._botId = "";
     this.state = "disconnected";
     this._callbacks.onDisconnected?.();
   }
@@ -415,10 +417,9 @@ export class LiveKitTransport extends Transport {
       screenAudio: getTrack(local, "audio", Track.Source.ScreenShareAudio),
     };
 
-    const remoteParticipants = Array.from(
-      this._room.remoteParticipants.values()
-    );
-    const botParticipant = remoteParticipants[0];
+    const botParticipant = this._botId
+      ? this._room.remoteParticipants.get(this._botId)
+      : undefined;
     const botTracks = botParticipant
       ? {
           audio: getTrack(botParticipant, "audio", Track.Source.Microphone),
@@ -568,13 +569,26 @@ export class LiveKitTransport extends Transport {
 
   private handleParticipantConnected(participant: RemoteParticipant) {
     this._callbacks.onParticipantJoined?.(this.toParticipant(participant));
+
+    // Mirrors the other transports: the first remote participant to join is
+    // treated as the bot for onBotConnected/onBotDisconnected purposes.
+    if (!this._botId) {
+      this._botId = participant.identity;
+      this._callbacks.onBotConnected?.(this.toParticipant(participant));
+    }
   }
 
   private handleParticipantDisconnected(participant: RemoteParticipant) {
     this._callbacks.onParticipantLeft?.(this.toParticipant(participant));
+
+    if (participant.identity === this._botId) {
+      this._botId = "";
+      this._callbacks.onBotDisconnected?.(this.toParticipant(participant));
+    }
   }
 
   private handleRoomDisconnected() {
+    this._botId = "";
     if (this.state !== "disconnected") {
       this.state = "disconnected";
       this._callbacks.onDisconnected?.();

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -181,8 +181,6 @@ export class LiveKitTransport extends Transport {
       throw new TransportStartError();
     }
 
-    if (this._abortController?.signal.aborted) return;
-
     if (this._localAudioTrack) {
       await this._room.localParticipant.publishTrack(this._localAudioTrack);
     } else if (this._micEnabled) {
@@ -193,6 +191,14 @@ export class LiveKitTransport extends Transport {
       await this._room.localParticipant.publishTrack(this._localVideoTrack);
     } else if (this._camEnabled) {
       await this._room.localParticipant.setCameraEnabled(true);
+    }
+
+    // room.connect() and the publish awaits above are all points at which a
+    // concurrent disconnect() may have aborted us and already set state to
+    // "disconnected". Guard here so we don't clobber that back to "connected".
+    if (this._abortController?.signal.aborted) {
+      await this._room.disconnect();
+      return;
     }
 
     this.state = "connected";

--- a/transports/livekit-transport/tsconfig.json
+++ b/transports/livekit-transport/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "skipLibCheck": true,
+    "jsx": "preserve",
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds a new @pipecat-ai/livekit-transport package to the monorepo — a WebRTC transport for @pipecat-ai/client-js built on LiveKit's infrastructure. Unlike the peer-to-peer small-webrtc-transport, this routes media through LiveKit's SFU, enabling multi-participant rooms, edge routing, and production-scale deployments.

What's included

- LiveKitTransport (src/liveKitTransport.ts) — extends the base Transport class and implements the full Pipecat
transport lifecycle:
  - Connection — flexible auth: fetch { url, token } from an authUrl (GET or POST with body), or pass url/token
directly to connect(). Constructor accepts LiveKit RoomOptions.
  - Device management — enumerate/switch mics, cams, and speakers via navigator.mediaDevices + LiveKit's
switchActiveDevice; hot-swapping via a devicechange listener; selected-device state synced to callbacks.
  - Media — mic/cam enable/disable, screen share (with audio), local + remote track publish/subscribe wired to
onTrackStarted/onTrackStopped.
  - Messaging — RTVI messages over LiveKit data channels (reliable), encoded/decoded via TextEncoder/TextDecoder.
  - Participants — join/leave callbacks; first remote participant treated as the bot.
  - State — mapped to Pipecat states (disconnected → ready/error), with abort-signal handling on connect.
- Package scaffolding — package.json, tsconfig.json, LICENSE (BSD-2-Clause), README.md, CHANGELOG.md, src/index.ts.
- Dependencies — livekit-client ^2.21.0; peer dep @pipecat-ai/client-js ^1.13.0.
- Docs — root README.md updated to list the new transport; package-lock.json regenerated.