### PR TITLE
Fix issues surrounding requestData in the offer endpoint

### DIFF
--- a/transports/small-webrtc-transport/CHANGELOG.md
+++ b/transports/small-webrtc-transport/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to **Pipecat Small WebRTC Transport** will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix issues surrounding requestData in the offer endpoint
+    1. If the endpoint was a Request type, any requestData provided would be lost
+    2. Now that runners cache the requestData provided to /start, we do not need to re-send it in the offer (which conveniently ALSO solves issues if the endpoint provided to start was a Request type :))
+
 ## [1.8.1]
 
 - Fixed issue causing `updateSpeaker()` not to work.

--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -238,7 +238,10 @@ export class SmallWebRTCTransport extends Transport {
         if (startEndpoint instanceof URL) {
           return startEndpoint.toString();
         }
-        if (startEndpoint instanceof Request) {
+        if (
+          typeof Request !== "undefined" &&
+          startEndpoint instanceof Request
+        ) {
           return startEndpoint.url;
         }
     }
@@ -307,7 +310,10 @@ export class SmallWebRTCTransport extends Transport {
     const offerUrl = this.offerUrlTemplate
       ? this.offerUrlTemplate.replace(":sessionId", sessionId)
       : startEndpoint.replace("/start", `/sessions/${sessionId}/api/offer`);
-    if (this.startBotParams!.endpoint instanceof Request) {
+    if (
+      typeof Request !== "undefined" &&
+      this.startBotParams!.endpoint instanceof Request
+    ) {
       return {
         endpoint: new Request(offerUrl, this.startBotParams?.endpoint),
       };
@@ -725,7 +731,10 @@ export class SmallWebRTCTransport extends Transport {
         restart_pc: recreatePeerConnection,
       };
       let request: APIRequest;
-      if (this._webrtcRequest.endpoint instanceof Request) {
+      if (
+        typeof Request !== "undefined" &&
+        this._webrtcRequest.endpoint instanceof Request
+      ) {
         request = {
           endpoint: new Request(this._webrtcRequest.endpoint, {
             body: JSON.stringify(requestData),

--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -646,13 +646,22 @@ export class SmallWebRTCTransport extends Transport {
       this._candidateQueue.length,
     );
 
+    let headers;
     try {
-      const headers = new Headers({
-        "Content-Type": "application/json",
-        ...Object.fromEntries(
-          (this._webrtcRequest.headers ?? new Headers()).entries(),
-        ),
-      });
+      if (
+        typeof Request !== "undefined" &&
+        this._webrtcRequest.endpoint instanceof Request
+      ) {
+        console.log("Using Request object headers");
+        headers = this._webrtcRequest.endpoint.headers;
+      } else {
+        headers = new Headers({
+          "Content-Type": "application/json",
+          ...Object.fromEntries(
+            (this._webrtcRequest.headers ?? new Headers()).entries(),
+          ),
+        });
+      }
 
       const payload = {
         pc_id: this.pc_id,


### PR DESCRIPTION
1. If the endpoint was a Request type, any requestData provided would be lost
2. Now that runners cache the requestData provided to /start, we do not need to re-send it in the offer (which conveniently solves issues if the endpoint provided to start was a Request type :))

This PR pairs nicely with https://github.com/pipecat-ai/pipecat-client-web/pull/171 -- though, not _technically_ dependent on it.