### PR TITLE
Fixed Gemini Live WebSocket Transport Connection

### DIFF
--- a/examples/directToLLMTransports/package-lock.json
+++ b/examples/directToLLMTransports/package-lock.json
@@ -31,7 +31,7 @@
     },
     "../../transports/gemini-live-websocket-transport": {
       "name": "@pipecat-ai/gemini-live-websocket-transport",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.86.0"
@@ -49,7 +49,7 @@
     },
     "../../transports/openai-realtime-webrtc-transport": {
       "name": "@pipecat-ai/openai-realtime-webrtc-transport",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.86.0",

--- a/examples/directToLLMTransports/src/app.ts
+++ b/examples/directToLLMTransports/src/app.ts
@@ -105,7 +105,7 @@ function geminiServiceOptions() {
   // Configure Gemini LLM service options
   const llm_service_options: GeminiLLMServiceOptions = {
     api_key: import.meta.env.VITE_DANGEROUS_GEMINI_API_KEY,
-    model: "models/gemini-2.0-flash-exp",
+    model: "models/gemini-2.5-flash-native-audio-preview-12-2025",
     initial_messages: [
       // Set up initial system and user messages.
       // Without the user message, the bot will not respond immediately
@@ -117,6 +117,7 @@ function geminiServiceOptions() {
       { role: "user", content: "Hello!" },
     ],
     settings: {
+      response_modalities: "AUDIO",
       speech_config: {
         voice_config: {
           prebuilt_voice_config: {

--- a/transports/gemini-live-websocket-transport/CHANGELOG.md
+++ b/transports/gemini-live-websocket-transport/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to **Pipecat GeminiLiveWebsocketTransport** will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fixed a connection bug in `GeminiLiveWebSocketTransport` caused by an outdated API path. 
+  - The `BidiGenerateContent` path was pointing to `v1alpha`, which is no longer valid. Updated to `v1beta`.
+- Updated default model from `gemini-2.0-flash-exp` to `gemini-2.5-flash-native-audio-preview-12-2025` in both the transport and the example app.
+- Added `response_modalities: "AUDIO"` to the example app's Gemini service options, required for the new model to respond with audio.
+
 ## [1.5.0]
 
 - Bump client-js version to work with latest 1.6.0 and support latest features

--- a/transports/gemini-live-websocket-transport/src/geminiLiveWebSocketTransport.ts
+++ b/transports/gemini-live-websocket-transport/src/geminiLiveWebSocketTransport.ts
@@ -17,8 +17,8 @@ import {
 } from "./directToLLMBaseWebSocketTransport";
 
 const HOST = `generativelanguage.googleapis.com`;
-const BIDI_PATH = `google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContent`;
-const MODEL = "models/gemini-2.0-flash-exp";
+const BIDI_PATH = `google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent`;
+const MODEL = "models/gemini-2.5-flash-native-audio-preview-12-2025";
 
 export interface GeminiLLMServiceOptions extends LLMServiceOptions {
   initial_messages?: Array<{ content: string; role: string }>;


### PR DESCRIPTION
 - Fixed a connection bug in `GeminiLiveWebSocketTransport` caused by an outdated API path. The BidiGenerateContent path was pointing to `v1alpha`, which is no longer valid. Updated to `v1beta`.
  - Updated default model from `gemini-2.0-flash-exp` to `gemini-2.5-flash-native-audio-preview-12-2025` in both the transport and the example app.
  - Added `response_modalities: "AUDIO"` to the example app's Gemini service options, required for the new model to respond with audio.