### PR TITLE
fix(small-webrtc,websocket): Fix bot disconnection logic to match Daily

### DIFF
--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -434,7 +434,7 @@ export class SmallWebRTCTransport extends Transport {
     // Note: This shouldn't happen since client-js should have already checked this
     if (!messageSizeWithinLimit(message, this._maxMessageSize)) {
       throw new MessageTooLargeError(
-        "Message data too large. Max size is " + this._maxMessageSize,
+        "Message data too large. Max size is " + this._maxMessageSize
       );
     }
     this.dc?.send(JSON.stringify(message));
@@ -889,7 +889,7 @@ export class SmallWebRTCTransport extends Transport {
         void this.attemptReconnection(false);
         break;
       case PEER_LEFT_TYPE:
-        void this.disconnect();
+        this._callbacks.onBotDisconnected?.();
         break;
       default:
         logger.warn("Unknown signalling message:", signallingMessage.message);

--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -8,6 +8,7 @@ import {
   MessageTooLargeError,
   RTVIError,
   RTVIMessage,
+  Participant,
   PipecatClientOptions,
   Tracks,
   Transport,
@@ -391,6 +392,7 @@ export class SmallWebRTCTransport extends Transport {
 
     this.state = "connected";
     this._callbacks.onConnected?.();
+    this._callbacks.onBotConnected?.(botParticipant(this.pc_id));
   }
 
   private syncTrackStatus() {
@@ -889,7 +891,7 @@ export class SmallWebRTCTransport extends Transport {
         void this.attemptReconnection(false);
         break;
       case PEER_LEFT_TYPE:
-        this._callbacks.onBotDisconnected?.();
+        this._callbacks.onBotDisconnected?.(botParticipant(this.pc_id));
         break;
       default:
         logger.warn("Unknown signalling message:", signallingMessage.message);
@@ -1131,3 +1133,9 @@ export class SmallWebRTCTransport extends Transport {
     return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   }
 }
+
+const botParticipant = (pc_id?: string | null): Participant => ({
+  id: pc_id || "bot",
+  local: false,
+  name: "bot",
+});

--- a/transports/websocket-transport/src/webSocketTransport.ts
+++ b/transports/websocket-transport/src/webSocketTransport.ts
@@ -309,9 +309,7 @@ export class WebSocketTransport extends Transport {
   }
 
   connectionError(errorMsg: string): void {
-    console.error(errorMsg);
-    this.state = "error";
-    void this.disconnect();
+    this._callbacks.onError?.(RTVIMessage.error(errorMsg, true));
   }
 
   // Not implemented


### PR DESCRIPTION
This change enforces a common disconnect pattern where instead of immediately disconnecting the transport (and maybe not even telling the client about it), we trigger the client's onBotDisconnected event and leave it to the client to decide to disconnect.

Also, let's not be strict about how people write their commit content.

This PR depends on https://github.com/pipecat-ai/pipecat-client-web/pull/185