### PR TITLE
ci: fix release-please config and changelog generation

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,11 +1,8 @@
 {
   "extends": ["@commitlint/config-conventional"],
   "rules": {
-    "scope-enum": [
-      2,
-      "always",
-      ["daily", "gemini", "openai", "small-webrtc", "websocket", ""]
-    ],
+    "scope-enum": [0],
+    "scope-empty": [0],
     "body-max-line-length": [0],
     "footer-max-line-length": [0],
     "header-case": [0],

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
   "release-type": "node",
   "include-component-in-tag": true,
   "separate-pull-requests": true,
-  "pull-request-title-pattern": "chore: release ${component} ${version}",
+  "pull-request-title-pattern": "chore${scope}: release ${component} ${version}",
+  "exclude-merges": true,
   "packages": {
     "transports/daily": {
       "component": "daily-transport",
@@ -36,9 +37,9 @@
     { "type": "fix", "section": "Bug Fixes" },
     { "type": "perf", "section": "Performance Improvements" },
     { "type": "revert", "section": "Reverts" },
+    { "type": "chore", "section": "Miscellaneous Chores" },
     { "type": "docs", "section": "Documentation", "hidden": true },
     { "type": "style", "section": "Styles", "hidden": true },
-    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
     { "type": "refactor", "section": "Code Refactoring", "hidden": true },
     { "type": "test", "section": "Tests", "hidden": true },
     { "type": "build", "section": "Build System", "hidden": true },


### PR DESCRIPTION
Closes #109

## Summary
Addresses the release-please issues reported in #109:

- **Publish jobs skipped after merging release PRs** (#109 item 6): The `pull-request-title-pattern` was missing `${scope}`, which release-please uses to map merged PRs back to their component. Without it, `release_created` was never set to `true` so all publish jobs were skipped. Fixed by changing the pattern from `"chore: release ..."` to `"chore${scope}: release ..."`.
- **Duplicate changelog entries from merge commits** (#109 item 3): Added `exclude-merges: true` to release-please config.
- **Missing dependency bump entries** (#109 item 4): Unhid `chore` type in changelog sections so dependency updates appear in changelogs.
- **Redundant scope in changelogs** (#109 item 6 suggestion): Made commitlint scope fully optional for developer commits — since release-please generates per-package changelogs based on file paths, the scope prefix is redundant. Release PR titles still include scope (via `${scope}`) for component matching.

### Items that should resolve with these fixes
- **Missing release PRs for gemini/openai** (#109 item 1): Likely caused by no user-facing commits touching those packages since the last release. With `chore` now visible in changelogs, dependency bumps will trigger release PRs.
- **Stale changelog entries** (#109 item 2): The dated entries were a one-time artifact. `exclude-merges` prevents future duplicates.
- **Manual changelog edits not in release notes** (#109 item 5): With the above fixes reducing the need for manual edits, this should be less of an issue going forward.

## Test plan
- [ ] Next release cycle should produce clean changelogs without duplicates
- [ ] Merging a release PR should trigger the corresponding publish job
- [ ] Commits without scope should pass commitlint