### PR TITLE
test: characterize initDevices() across all transports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Run tests
+        run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "pipecat-client-web-transports",
       "version": "0.0.0",
       "workspaces": [
-        "transports/*"
+        "transports/*",
+        "tests"
       ],
       "devDependencies": {
         "@commitlint/cli": "^20.0.0",
@@ -393,6 +394,397 @@
         "node": ">=22.14.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
@@ -582,6 +974,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@lezer/common": {
       "version": "1.5.1",
@@ -2592,6 +2991,10 @@
         "@parcel/core": "^2.16.4"
       }
     },
+    "node_modules/@pipecat-ai-transports/characterization-tests": {
+      "resolved": "tests",
+      "link": true
+    },
     "node_modules/@pipecat-ai/client-js": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.7.0.tgz",
@@ -2670,6 +3073,356 @@
       "dependencies": {
         "@protobuf-ts/runtime": "^2.11.1"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@sentry-internal/browser-utils": {
       "version": "8.55.0",
@@ -3020,6 +3773,119 @@
         "typescript": "*"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "dev": true,
@@ -3081,6 +3947,16 @@
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3157,6 +4033,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "dev": true,
@@ -3186,6 +4072,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -3199,6 +4102,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -3483,6 +4396,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -3562,6 +4485,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -3580,6 +4516,52 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escalade": {
@@ -3752,6 +4734,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "dev": true,
@@ -3765,6 +4757,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3843,6 +4845,21 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -3930,6 +4947,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "15.11.7",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
+      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.5.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/has-flag": {
@@ -4549,6 +5581,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -4647,6 +5696,25 @@
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -4829,6 +5897,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
@@ -4845,6 +5930,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -4929,6 +6043,51 @@
         "node": ">=4"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
@@ -4999,6 +6158,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -5008,6 +6184,20 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -5044,6 +6234,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -5052,6 +6249,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -5166,12 +6393,188 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/weak-lru-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5185,6 +6588,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -5300,9 +6720,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "tests": {
+      "name": "@pipecat-ai-transports/characterization-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@pipecat-ai/client-js": "^1.7.0",
+        "@pipecat-ai/daily-transport": "*",
+        "@pipecat-ai/gemini-live-websocket-transport": "*",
+        "@pipecat-ai/openai-realtime-webrtc-transport": "*",
+        "@pipecat-ai/small-webrtc-transport": "*",
+        "@pipecat-ai/websocket-transport": "*",
+        "happy-dom": "^15.11.7",
+        "typescript": "^5.5.4",
+        "vitest": "^2.1.8"
+      }
+    },
     "transports/daily": {
       "name": "@pipecat-ai/daily-transport",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.89.1"
@@ -5356,7 +6791,7 @@
     },
     "transports/small-webrtc-transport": {
       "name": "@pipecat-ai/small-webrtc-transport",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.89.1",
@@ -5377,7 +6812,7 @@
     },
     "transports/websocket-transport": {
       "name": "@pipecat-ai/websocket-transport",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.89.1",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "node": ">=22.14.0"
   },
   "workspaces": [
-    "transports/*"
+    "transports/*",
+    "tests"
   ],
   "scripts": {
-    "build": "npm run build --workspaces",
-    "prepare": "husky"
+    "build": "npm run build --workspaces --if-present",
+    "prepare": "husky",
+    "test": "npm run test --workspace @pipecat-ai-transports/characterization-tests"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.0.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@pipecat-ai-transports/characterization-tests",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Characterization tests for Pipecat transports. Not published; runs via the root workspace.",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@pipecat-ai/client-js": "^1.7.0",
+    "@pipecat-ai/daily-transport": "*",
+    "@pipecat-ai/gemini-live-websocket-transport": "*",
+    "@pipecat-ai/openai-realtime-webrtc-transport": "*",
+    "@pipecat-ai/small-webrtc-transport": "*",
+    "@pipecat-ai/websocket-transport": "*",
+    "happy-dom": "^15.11.7",
+    "typescript": "^5.5.4",
+    "vitest": "^2.1.8"
+  }
+}

--- a/tests/src/helpers/fakeDaily.ts
+++ b/tests/src/helpers/fakeDaily.ts
@@ -20,24 +20,12 @@ export interface FakeDailyCallObject {
 }
 
 export function createFakeDailyCallObject(): FakeDailyCallObject {
-  const fake = {
+  const fake: FakeDailyCallObject = {
     startCameraCallCount: 0,
-    startCameraShouldThrow: undefined as Error | undefined,
+    startCameraShouldThrow: undefined,
     on: vi.fn(),
     off: vi.fn(),
-    startCamera: vi.fn(async function (this: FakeDailyCallObject) {
-      this.startCameraCallCount += 1;
-      if (this.startCameraShouldThrow) throw this.startCameraShouldThrow;
-      return {
-        camera: { deviceId: "cam-1", label: "Fake Cam", kind: "videoinput" },
-        mic: { deviceId: "mic-1", label: "Fake Mic", kind: "audioinput" },
-        speaker: {
-          deviceId: "spk-1",
-          label: "Fake Speaker",
-          kind: "audiooutput",
-        },
-      };
-    }),
+    startCamera: vi.fn(),
     enumerateDevices: vi.fn(async () => ({ devices: [] })),
     isLocalAudioLevelObserverRunning: vi.fn(() => false),
     isRemoteParticipantsAudioLevelObserverRunning: vi.fn(() => false),
@@ -45,8 +33,22 @@ export function createFakeDailyCallObject(): FakeDailyCallObject {
     startRemoteParticipantsAudioLevelObserver: vi.fn(async () => {}),
   };
 
-  // bind startCamera so `this` resolves correctly in the async function above
-  fake.startCamera = fake.startCamera.bind(fake) as Mock;
+  // Close over `fake` rather than binding `this` — vitest loses its Mock
+  // identity through Function.prototype.bind, which breaks
+  // toHaveBeenCalledTimes etc.
+  fake.startCamera.mockImplementation(async () => {
+    fake.startCameraCallCount += 1;
+    if (fake.startCameraShouldThrow) throw fake.startCameraShouldThrow;
+    return {
+      camera: { deviceId: "cam-1", label: "Fake Cam", kind: "videoinput" },
+      mic: { deviceId: "mic-1", label: "Fake Mic", kind: "audioinput" },
+      speaker: {
+        deviceId: "spk-1",
+        label: "Fake Speaker",
+        kind: "audiooutput",
+      },
+    };
+  });
 
-  return fake as FakeDailyCallObject;
+  return fake;
 }

--- a/tests/src/helpers/fakeDaily.ts
+++ b/tests/src/helpers/fakeDaily.ts
@@ -1,0 +1,52 @@
+/**
+ * Fake daily-js call object for characterization tests. Covers only the
+ * surface that DailyTransport / OpenAI-WebRTC transport exercises during
+ * initialize() and initDevices().
+ */
+
+import { vi, type Mock } from "vitest";
+
+export interface FakeDailyCallObject {
+  on: Mock;
+  off: Mock;
+  startCamera: Mock;
+  enumerateDevices: Mock;
+  isLocalAudioLevelObserverRunning: Mock;
+  isRemoteParticipantsAudioLevelObserverRunning: Mock;
+  startLocalAudioLevelObserver: Mock;
+  startRemoteParticipantsAudioLevelObserver: Mock;
+  startCameraCallCount: number;
+  startCameraShouldThrow?: Error;
+}
+
+export function createFakeDailyCallObject(): FakeDailyCallObject {
+  const fake = {
+    startCameraCallCount: 0,
+    startCameraShouldThrow: undefined as Error | undefined,
+    on: vi.fn(),
+    off: vi.fn(),
+    startCamera: vi.fn(async function (this: FakeDailyCallObject) {
+      this.startCameraCallCount += 1;
+      if (this.startCameraShouldThrow) throw this.startCameraShouldThrow;
+      return {
+        camera: { deviceId: "cam-1", label: "Fake Cam", kind: "videoinput" },
+        mic: { deviceId: "mic-1", label: "Fake Mic", kind: "audioinput" },
+        speaker: {
+          deviceId: "spk-1",
+          label: "Fake Speaker",
+          kind: "audiooutput",
+        },
+      };
+    }),
+    enumerateDevices: vi.fn(async () => ({ devices: [] })),
+    isLocalAudioLevelObserverRunning: vi.fn(() => false),
+    isRemoteParticipantsAudioLevelObserverRunning: vi.fn(() => false),
+    startLocalAudioLevelObserver: vi.fn(async () => {}),
+    startRemoteParticipantsAudioLevelObserver: vi.fn(async () => {}),
+  };
+
+  // bind startCamera so `this` resolves correctly in the async function above
+  fake.startCamera = fake.startCamera.bind(fake) as Mock;
+
+  return fake as FakeDailyCallObject;
+}

--- a/tests/src/helpers/fakeMediaManager.ts
+++ b/tests/src/helpers/fakeMediaManager.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal MediaManager double for transports that accept DI. We avoid pulling
+ * the real DailyMediaManager / WavMediaManager so tests don't depend on
+ * WavRecorder, AudioContext, or navigator.mediaDevices.
+ *
+ * The transports we inject into (SmallWebRTC, WebSocket, Gemini Live) call a
+ * tiny slice of MediaManager's surface during initialize() and initDevices():
+ * setUserAudioCallback, setClientOptions, and initialize(). This fake covers
+ * that slice plus the abstract-class members needed for a structural match,
+ * and is cast to MediaManager at each injection site to avoid importing the
+ * MediaManager type (which transitively pulls wavtools without types).
+ */
+
+import { vi } from "vitest";
+
+export interface FakeMediaManager {
+  initializeCallCount: number;
+  initializeShouldThrow?: Error;
+  initialize: (...args: unknown[]) => Promise<void>;
+  setUserAudioCallback: (...args: unknown[]) => void;
+  setClientOptions: (...args: unknown[]) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export function createFakeMediaManager(): FakeMediaManager {
+  const fake: FakeMediaManager = {
+    initializeCallCount: 0,
+    initializeShouldThrow: undefined,
+
+    setUserAudioCallback: vi.fn(),
+    setClientOptions: vi.fn(),
+
+    initialize: vi.fn(async function (this: FakeMediaManager) {
+      this.initializeCallCount += 1;
+      if (this.initializeShouldThrow) throw this.initializeShouldThrow;
+    }),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+
+    userStartedSpeaking: vi.fn(async () => undefined),
+    bufferBotAudio: vi.fn(() => undefined),
+
+    getAllMics: vi.fn(async () => []),
+    getAllCams: vi.fn(async () => []),
+    getAllSpeakers: vi.fn(async () => []),
+
+    updateMic: vi.fn(),
+    updateCam: vi.fn(),
+    updateSpeaker: vi.fn(),
+
+    selectedMic: {},
+    selectedCam: {},
+    selectedSpeaker: {},
+
+    enableMic: vi.fn(),
+    enableCam: vi.fn(),
+    enableScreenShare: vi.fn(),
+
+    isCamEnabled: false,
+    isMicEnabled: true,
+    isSharingScreen: false,
+    supportsScreenShare: false,
+
+    tracks: vi.fn(() => ({ local: { audio: undefined, video: undefined } })),
+  };
+
+  // Bind the initialize implementation so `this` resolves to the fake itself.
+  const boundInit = fake.initialize.bind(fake);
+  fake.initialize = boundInit;
+
+  return fake;
+}

--- a/tests/src/helpers/observeTransport.ts
+++ b/tests/src/helpers/observeTransport.ts
@@ -103,14 +103,17 @@ export function buildSpyCallbacks(): {
  */
 export function buildClientOptions(
   transport: Transport,
-  callbacks: RTVIEventCallbacks
+  callbacks: RTVIEventCallbacks,
+  overrides: Partial<
+    Pick<PipecatClientOptions, "enableMic" | "enableCam" | "enableScreenShare">
+  > = {}
 ): PipecatClientOptions {
   return {
     transport,
     callbacks,
-    enableMic: true,
-    enableCam: false,
-    enableScreenShare: false,
+    enableMic: overrides.enableMic ?? true,
+    enableCam: overrides.enableCam ?? false,
+    enableScreenShare: overrides.enableScreenShare ?? false,
   };
 }
 
@@ -121,9 +124,15 @@ export function buildClientOptions(
  */
 export function wireTransport(
   transport: Transport,
-  callbacks: RTVIEventCallbacks
+  callbacks: RTVIEventCallbacks,
+  overrides: Partial<
+    Pick<PipecatClientOptions, "enableMic" | "enableCam" | "enableScreenShare">
+  > = {}
 ): { onMessage: Mock<(ev: RTVIMessage) => void> } {
   const onMessage = vi.fn<(ev: RTVIMessage) => void>();
-  transport.initialize(buildClientOptions(transport, callbacks), onMessage);
+  transport.initialize(
+    buildClientOptions(transport, callbacks, overrides),
+    onMessage
+  );
   return { onMessage };
 }

--- a/tests/src/helpers/observeTransport.ts
+++ b/tests/src/helpers/observeTransport.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared helpers for transport characterization tests.
+ *
+ * These exist so each transport's spec file can be small and focused on the
+ * behavior being locked in — today's initDevices() contract, per the Plan A
+ * Notion page. Replace these helpers only when the Transport abstract contract
+ * itself changes.
+ */
+
+import type {
+  PipecatClientOptions,
+  RTVIEventCallbacks,
+  RTVIMessage,
+  Transport,
+  TransportState,
+} from "@pipecat-ai/client-js";
+import { vi, type Mock } from "vitest";
+
+/**
+ * A record of every TransportState the transport emits through
+ * onTransportStateChanged, in order. Populated by wireCallbacks().
+ */
+export interface StateRecorder {
+  states: TransportState[];
+}
+
+/**
+ * Build the full callback shape with each member wired to a vitest spy. The
+ * onTransportStateChanged spy also pushes into the returned StateRecorder for
+ * ergonomic sequence assertions.
+ */
+export function buildSpyCallbacks(): {
+  callbacks: RTVIEventCallbacks;
+  spies: { [K in keyof RTVIEventCallbacks]-?: Mock };
+  recorder: StateRecorder;
+} {
+  const recorder: StateRecorder = { states: [] };
+
+  const spies = {
+    onConnected: vi.fn(),
+    onDisconnected: vi.fn(),
+    onError: vi.fn(),
+    onTransportStateChanged: vi.fn((state: TransportState) => {
+      recorder.states.push(state);
+    }),
+    onBotStarted: vi.fn(),
+    onBotConnected: vi.fn(),
+    onBotReady: vi.fn(),
+    onBotDisconnected: vi.fn(),
+    onMetrics: vi.fn(),
+    onServerMessage: vi.fn(),
+    onMessageError: vi.fn(),
+    onParticipantJoined: vi.fn(),
+    onParticipantLeft: vi.fn(),
+    onAvailableCamsUpdated: vi.fn(),
+    onAvailableMicsUpdated: vi.fn(),
+    onAvailableSpeakersUpdated: vi.fn(),
+    onCamUpdated: vi.fn(),
+    onMicUpdated: vi.fn(),
+    onSpeakerUpdated: vi.fn(),
+    onDeviceError: vi.fn(),
+    onTrackStarted: vi.fn(),
+    onTrackStopped: vi.fn(),
+    onScreenTrackStarted: vi.fn(),
+    onScreenTrackStopped: vi.fn(),
+    onScreenShareError: vi.fn(),
+    onLocalAudioLevel: vi.fn(),
+    onRemoteAudioLevel: vi.fn(),
+    onUserStartedSpeaking: vi.fn(),
+    onUserStoppedSpeaking: vi.fn(),
+    onBotStartedSpeaking: vi.fn(),
+    onBotStoppedSpeaking: vi.fn(),
+    onUserMuteStarted: vi.fn(),
+    onUserMuteStopped: vi.fn(),
+    onUserTranscript: vi.fn(),
+    onBotOutput: vi.fn(),
+    onBotTranscript: vi.fn(),
+    onBotLlmText: vi.fn(),
+    onBotLlmStarted: vi.fn(),
+    onBotLlmStopped: vi.fn(),
+    onBotTtsText: vi.fn(),
+    onBotTtsStarted: vi.fn(),
+    onBotTtsStopped: vi.fn(),
+    onLLMFunctionCallStarted: vi.fn(),
+    onLLMFunctionCallInProgress: vi.fn(),
+    onLLMFunctionCallStopped: vi.fn(),
+    onBotLlmSearchResponse: vi.fn(),
+    onLLMFunctionCall: vi.fn(),
+  } as unknown as { [K in keyof RTVIEventCallbacks]-?: Mock };
+
+  return {
+    callbacks: spies as unknown as RTVIEventCallbacks,
+    spies,
+    recorder,
+  };
+}
+
+/**
+ * A minimal PipecatClientOptions. The transport arg is a placeholder — the
+ * abstract Transport.initialize() API accepts the parent client options for
+ * reading callbacks; tests drive the transport directly without ever needing a
+ * real PipecatClient to own it.
+ */
+export function buildClientOptions(
+  transport: Transport,
+  callbacks: RTVIEventCallbacks
+): PipecatClientOptions {
+  return {
+    transport,
+    callbacks,
+    enableMic: true,
+    enableCam: false,
+    enableScreenShare: false,
+  };
+}
+
+/**
+ * Wire a transport up the way PipecatClient does: call initialize() with
+ * options + a message handler spy. Returns the spy so tests can assert on
+ * message delivery where relevant.
+ */
+export function wireTransport(
+  transport: Transport,
+  callbacks: RTVIEventCallbacks
+): { onMessage: Mock<(ev: RTVIMessage) => void> } {
+  const onMessage = vi.fn<(ev: RTVIMessage) => void>();
+  transport.initialize(buildClientOptions(transport, callbacks), onMessage);
+  return { onMessage };
+}

--- a/tests/src/transports/daily.spec.ts
+++ b/tests/src/transports/daily.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Characterization tests for DailyTransport's initDevices() contract.
+ *
+ * Locks in today's behavior ahead of Plan A step 2. Unlike the DI-friendly
+ * transports, DailyTransport instantiates the daily-js call object eagerly in
+ * its constructor, so we mock the whole module via vi.mock().
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  createFakeDailyCallObject,
+  type FakeDailyCallObject,
+} from "../helpers/fakeDaily";
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+// Module-scoped handle the mock can refer to. Each test assigns a fresh fake
+// before constructing the transport.
+let currentFakeDaily: FakeDailyCallObject | null = null;
+
+vi.mock("@daily-co/daily-js", () => ({
+  default: {
+    createCallObject: () => currentFakeDaily,
+  },
+}));
+
+// Import AFTER the mock is registered so the module picks up the stub.
+const { DailyTransport } = await import("@pipecat-ai/daily-transport");
+
+describe("DailyTransport.initDevices() — characterization", () => {
+  let fakeDaily: FakeDailyCallObject;
+  let transport: InstanceType<typeof DailyTransport>;
+
+  beforeEach(() => {
+    fakeDaily = createFakeDailyCallObject();
+    currentFakeDaily = fakeDaily;
+    transport = new DailyTransport();
+  });
+
+  test("initial state after construction is 'disconnected'", () => {
+    expect(transport.state).toBe("disconnected");
+  });
+
+  test("happy-path initDevices(): disconnected → initializing → initialized", async () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+
+    expect(fakeDaily.startCameraCallCount).toBe(1);
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual(["initializing", "initialized"]);
+  });
+
+  test("initDevices() fans out available-device + selected-device callbacks exactly once", async () => {
+    const { callbacks, spies } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+
+    // Available-device lists (even if empty — the callback itself fires).
+    expect(spies.onAvailableCamsUpdated).toHaveBeenCalledTimes(1);
+    expect(spies.onAvailableMicsUpdated).toHaveBeenCalledTimes(1);
+    expect(spies.onAvailableSpeakersUpdated).toHaveBeenCalledTimes(1);
+    // Selected-device info derived from startCamera's return value.
+    expect(spies.onCamUpdated).toHaveBeenCalledTimes(1);
+    expect(spies.onMicUpdated).toHaveBeenCalledTimes(1);
+    expect(spies.onSpeakerUpdated).toHaveBeenCalledTimes(1);
+  });
+
+  test("repeated initDevices() calls re-invoke startCamera and re-emit state transitions", async () => {
+    // Today DailyTransport is NOT idempotent: a second call re-runs the full
+    // startCamera/enumerate flow. Step 2 introduces a MediaState gate that
+    // short-circuits repeat calls at the PipecatClient layer.
+    const { callbacks, recorder, spies } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+    await transport.initDevices();
+
+    expect(fakeDaily.startCameraCallCount).toBe(2);
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual([
+      "initializing",
+      "initialized",
+      "initializing",
+      "initialized",
+    ]);
+    // Device callbacks fire twice as well — consumers see duplicate updates.
+    expect(spies.onMicUpdated).toHaveBeenCalledTimes(2);
+    expect(spies.onCamUpdated).toHaveBeenCalledTimes(2);
+  });
+
+  test("second initDevices() does NOT restart audio observers (partial internal idempotency)", async () => {
+    // The one place DailyTransport guards against repeats is the audio-level
+    // observers: it checks isLocalAudioLevelObserverRunning() before starting
+    // them. This partial idempotency is what step 2 should preserve when it
+    // short-circuits repeat initDevices calls.
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+
+    // First call sees both observers as not running and starts them. Flip
+    // the fakes so the second call sees "already running".
+    fakeDaily.isLocalAudioLevelObserverRunning.mockReturnValue(true);
+    fakeDaily.isRemoteParticipantsAudioLevelObserverRunning.mockReturnValue(
+      true
+    );
+
+    await transport.initDevices();
+
+    expect(fakeDaily.startLocalAudioLevelObserver).toHaveBeenCalledTimes(1);
+    expect(
+      fakeDaily.startRemoteParticipantsAudioLevelObserver
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  test("initDevices() rejection propagates and leaves state at 'initializing'", async () => {
+    fakeDaily.startCameraShouldThrow = new Error("permission denied");
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await expect(transport.initDevices()).rejects.toThrow("permission denied");
+    expect(transport.state).toBe("initializing");
+    expect(recorder.states).toEqual(["initializing"]);
+  });
+});

--- a/tests/src/transports/daily.spec.ts
+++ b/tests/src/transports/daily.spec.ts
@@ -116,6 +116,38 @@ describe("DailyTransport.initDevices() — characterization", () => {
     ).toHaveBeenCalledTimes(1);
   });
 
+  test.each([
+    [
+      { enableMic: true, enableCam: false },
+      { startAudioOff: false, startVideoOff: true },
+    ],
+    [
+      { enableMic: false, enableCam: false },
+      { startAudioOff: true, startVideoOff: true },
+    ],
+    [
+      { enableMic: true, enableCam: true },
+      { startAudioOff: false, startVideoOff: false },
+    ],
+    [
+      { enableMic: false, enableCam: true },
+      { startAudioOff: true, startVideoOff: false },
+    ],
+  ])(
+    "initialize(%j) propagates enableMic/enableCam to startCamera as %j",
+    async (opts, expectedCallArg) => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, opts);
+
+      await transport.initDevices();
+
+      expect(fakeDaily.startCamera).toHaveBeenCalledTimes(1);
+      expect(fakeDaily.startCamera).toHaveBeenCalledWith(
+        expect.objectContaining(expectedCallArg)
+      );
+    }
+  );
+
   test("initDevices() rejection propagates and leaves state at 'initializing'", async () => {
     fakeDaily.startCameraShouldThrow = new Error("permission denied");
     const { callbacks, recorder } = buildSpyCallbacks();

--- a/tests/src/transports/geminiLive.spec.ts
+++ b/tests/src/transports/geminiLive.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Characterization tests for GeminiLiveWebsocketTransport's initDevices()
+ * contract. Locks in today's behavior ahead of Plan A step 2.
+ */
+
+import { GeminiLiveWebsocketTransport } from "@pipecat-ai/gemini-live-websocket-transport";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createFakeMediaManager } from "../helpers/fakeMediaManager";
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+describe("GeminiLiveWebsocketTransport.initDevices() — characterization", () => {
+  let mediaManager: ReturnType<typeof createFakeMediaManager>;
+  let transport: GeminiLiveWebsocketTransport;
+
+  beforeEach(() => {
+    mediaManager = createFakeMediaManager();
+    transport = new GeminiLiveWebsocketTransport(
+      { api_key: "test-key" },
+      mediaManager as never
+    );
+  });
+
+  test("initial state after construction is 'disconnected'", () => {
+    expect(transport.state).toBe("disconnected");
+  });
+
+  test("happy-path initDevices(): disconnected → initializing → initialized", async () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+
+    expect(mediaManager.initializeCallCount).toBe(1);
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual(["initializing", "initialized"]);
+  });
+
+  test("repeated initDevices() calls re-enter 'initializing' each time (NOT idempotent at the transport layer)", async () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+    await transport.initDevices();
+
+    expect(mediaManager.initializeCallCount).toBe(2);
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual([
+      "initializing",
+      "initialized",
+      "initializing",
+      "initialized",
+    ]);
+  });
+
+  test("initDevices() rejection propagates and leaves state at 'initializing'", async () => {
+    mediaManager.initializeShouldThrow = new Error("wav init failed");
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await expect(transport.initDevices()).rejects.toThrow("wav init failed");
+    expect(transport.state).toBe("initializing");
+    expect(recorder.states).toEqual(["initializing"]);
+  });
+});

--- a/tests/src/transports/geminiLive.spec.ts
+++ b/tests/src/transports/geminiLive.spec.ts
@@ -53,6 +53,24 @@ describe("GeminiLiveWebsocketTransport.initDevices() — characterization", () =
     ]);
   });
 
+  test.each([
+    [{ enableMic: true, enableCam: false }],
+    [{ enableMic: false, enableCam: false }],
+    [{ enableMic: true, enableCam: true }],
+    [{ enableMic: false, enableCam: true }],
+  ])(
+    "initialize(%j) forwards enableMic/enableCam through to mediaManager.setClientOptions",
+    (opts) => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, opts);
+
+      expect(mediaManager.setClientOptions).toHaveBeenCalledTimes(1);
+      expect(mediaManager.setClientOptions).toHaveBeenCalledWith(
+        expect.objectContaining(opts)
+      );
+    }
+  );
+
   test("initDevices() rejection propagates and leaves state at 'initializing'", async () => {
     mediaManager.initializeShouldThrow = new Error("wav init failed");
     const { callbacks, recorder } = buildSpyCallbacks();

--- a/tests/src/transports/openai.spec.ts
+++ b/tests/src/transports/openai.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Characterization tests for OpenAIRealTimeWebRTCTransport's initDevices()
+ * contract. Locks in today's behavior ahead of Plan A step 2.
+ *
+ * OpenAI's transport reuses daily-js internally for device management, so we
+ * mock @daily-co/daily-js here too. We also stub RTCPeerConnection because
+ * the transport constructs one inside initialize().
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  createFakeDailyCallObject,
+  type FakeDailyCallObject,
+} from "../helpers/fakeDaily";
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+let currentFakeDaily: FakeDailyCallObject | null = null;
+
+vi.mock("@daily-co/daily-js", () => ({
+  default: {
+    createCallObject: () => currentFakeDaily,
+    getCallInstance: () => null,
+  },
+}));
+
+// Minimal RTCPeerConnection stub — initialize() only constructs one and
+// assigns `ontrack` later. No ICE or data-channel behavior is exercised by
+// the tests below.
+class FakeRTCDataChannel {
+  addEventListener = vi.fn();
+  send = vi.fn();
+  close = vi.fn();
+}
+
+class FakeRTCPeerConnection {
+  ontrack: unknown = null;
+  addTransceiver = vi.fn();
+  addEventListener = vi.fn();
+  createDataChannel = vi.fn(() => new FakeRTCDataChannel());
+  close = vi.fn();
+}
+(globalThis as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
+  FakeRTCPeerConnection;
+
+const { OpenAIRealTimeWebRTCTransport } = await import(
+  "@pipecat-ai/openai-realtime-webrtc-transport"
+);
+
+describe("OpenAIRealTimeWebRTCTransport.initDevices() — characterization", () => {
+  let fakeDaily: FakeDailyCallObject;
+  let transport: InstanceType<typeof OpenAIRealTimeWebRTCTransport>;
+
+  beforeEach(() => {
+    fakeDaily = createFakeDailyCallObject();
+    currentFakeDaily = fakeDaily;
+    transport = new OpenAIRealTimeWebRTCTransport({ api_key: "test-key" });
+  });
+
+  test("initial state after construction is 'disconnected'", () => {
+    expect(transport.state).toBe("disconnected");
+  });
+
+  test("happy-path initDevices(): disconnected → initializing → initialized", async () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+
+    expect(fakeDaily.startCameraCallCount).toBe(1);
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual(["initializing", "initialized"]);
+  });
+
+  test("initDevices() fans out available-device + selected-device callbacks exactly once", async () => {
+    const { callbacks, spies } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+
+    expect(spies.onAvailableCamsUpdated).toHaveBeenCalledTimes(1);
+    expect(spies.onAvailableMicsUpdated).toHaveBeenCalledTimes(1);
+    expect(spies.onAvailableSpeakersUpdated).toHaveBeenCalledTimes(1);
+    expect(spies.onCamUpdated).toHaveBeenCalledTimes(1);
+    expect(spies.onMicUpdated).toHaveBeenCalledTimes(1);
+    expect(spies.onSpeakerUpdated).toHaveBeenCalledTimes(1);
+  });
+
+  test("repeated initDevices() calls re-invoke startCamera and re-emit state transitions", async () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+    await transport.initDevices();
+
+    expect(fakeDaily.startCameraCallCount).toBe(2);
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual([
+      "initializing",
+      "initialized",
+      "initializing",
+      "initialized",
+    ]);
+  });
+
+  test("second initDevices() does NOT restart the local audio observer (partial internal idempotency)", async () => {
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+    fakeDaily.isLocalAudioLevelObserverRunning.mockReturnValue(true);
+
+    await transport.initDevices();
+
+    expect(fakeDaily.startLocalAudioLevelObserver).toHaveBeenCalledTimes(1);
+  });
+
+  test("initDevices() rejection propagates and leaves state at 'initializing'", async () => {
+    fakeDaily.startCameraShouldThrow = new Error("permission denied");
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await expect(transport.initDevices()).rejects.toThrow("permission denied");
+    expect(transport.state).toBe("initializing");
+    expect(recorder.states).toEqual(["initializing"]);
+  });
+});

--- a/tests/src/transports/openai.spec.ts
+++ b/tests/src/transports/openai.spec.ts
@@ -115,6 +115,31 @@ describe("OpenAIRealTimeWebRTCTransport.initDevices() — characterization", () 
     expect(fakeDaily.startLocalAudioLevelObserver).toHaveBeenCalledTimes(1);
   });
 
+  test.each([
+    [{ enableMic: true, enableCam: false }, { startAudioOff: false }],
+    [{ enableMic: false, enableCam: false }, { startAudioOff: true }],
+    [{ enableMic: true, enableCam: true }, { startAudioOff: false }],
+    [{ enableMic: false, enableCam: true }, { startAudioOff: true }],
+  ])(
+    "initDevices() with %j passes %j to startCamera (startVideoOff is hardcoded true regardless of enableCam)",
+    async (opts, expectedCallArg) => {
+      // OpenAI's transport hardcodes startVideoOff: true in initDevices, so
+      // enableCam: true does NOT actually turn the camera on at init time.
+      // enableMic flows through normally as startAudioOff: !enableMic.
+      // Lock this in — the Plan B work around per-transport device management
+      // (B3) will need to decide whether to keep this quirk.
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, opts);
+
+      await transport.initDevices();
+
+      expect(fakeDaily.startCamera).toHaveBeenCalledTimes(1);
+      expect(fakeDaily.startCamera).toHaveBeenCalledWith(
+        expect.objectContaining({ ...expectedCallArg, startVideoOff: true })
+      );
+    }
+  );
+
   test("initDevices() rejection propagates and leaves state at 'initializing'", async () => {
     fakeDaily.startCameraShouldThrow = new Error("permission denied");
     const { callbacks, recorder } = buildSpyCallbacks();

--- a/tests/src/transports/smallWebRtc.spec.ts
+++ b/tests/src/transports/smallWebRtc.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Characterization tests for SmallWebRTCTransport's initDevices() contract.
+ *
+ * Locks in today's behavior ahead of Plan A step 2, which will replace the
+ * 'disconnected' sentinel gate in PipecatClient with a MediaState check. Any
+ * behavior change here should be paired with a deliberate step-2 edit.
+ */
+
+import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createFakeMediaManager } from "../helpers/fakeMediaManager";
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+describe("SmallWebRTCTransport.initDevices() — characterization", () => {
+  let mediaManager: ReturnType<typeof createFakeMediaManager>;
+  let transport: SmallWebRTCTransport;
+
+  beforeEach(() => {
+    mediaManager = createFakeMediaManager();
+    // FakeMediaManager implements the runtime slice the transport uses but
+    // is not a subclass. Casting to `never` here avoids importing the
+    // MediaManager type (which transitively pulls wavtools without types).
+    transport = new SmallWebRTCTransport({
+      mediaManager: mediaManager as never,
+    });
+  });
+
+  test("initial state after construction is 'disconnected'", () => {
+    // Before initialize() runs, the abstract Transport's _state field is
+    // already 'disconnected'. The concrete constructor does not change this.
+    expect(transport.state).toBe("disconnected");
+  });
+
+  test("after initialize(): state is 'disconnected' (same sentinel as post-session)", () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    expect(transport.state).toBe("disconnected");
+    // initialize() explicitly sets 'disconnected' — one transition observed,
+    // even though the string value is unchanged.
+    expect(recorder.states).toEqual([]);
+  });
+
+  test("happy-path initDevices(): disconnected → initializing → initialized", async () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+
+    expect(mediaManager.initializeCallCount).toBe(1);
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual(["initializing", "initialized"]);
+  });
+
+  test("repeated initDevices() calls re-enter 'initializing' each time (NOT idempotent at the transport layer)", async () => {
+    // Today SmallWebRTC forwards unconditionally to mediaManager.initialize()
+    // and re-runs state transitions on every call. Step 2 will add a guard at
+    // the PipecatClient level based on MediaState, not on TransportState.
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+    await transport.initDevices();
+
+    expect(mediaManager.initializeCallCount).toBe(2);
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual([
+      "initializing",
+      "initialized",
+      "initializing",
+      "initialized",
+    ]);
+  });
+
+  test("initDevices() rejection propagates and leaves state at 'initializing'", async () => {
+    mediaManager.initializeShouldThrow = new Error("getUserMedia failed");
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await expect(transport.initDevices()).rejects.toThrow("getUserMedia failed");
+
+    // The transport does not catch; state set to 'initializing' lingers.
+    // PipecatClient consumers see a stuck state — Plan A's core motivation.
+    expect(transport.state).toBe("initializing");
+    expect(recorder.states).toEqual(["initializing"]);
+  });
+});

--- a/tests/src/transports/smallWebRtc.spec.ts
+++ b/tests/src/transports/smallWebRtc.spec.ts
@@ -73,6 +73,24 @@ describe("SmallWebRTCTransport.initDevices() — characterization", () => {
     ]);
   });
 
+  test.each([
+    [{ enableMic: true, enableCam: false }],
+    [{ enableMic: false, enableCam: false }],
+    [{ enableMic: true, enableCam: true }],
+    [{ enableMic: false, enableCam: true }],
+  ])(
+    "initialize(%j) forwards enableMic/enableCam through to mediaManager.setClientOptions",
+    (opts) => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, opts);
+
+      expect(mediaManager.setClientOptions).toHaveBeenCalledTimes(1);
+      expect(mediaManager.setClientOptions).toHaveBeenCalledWith(
+        expect.objectContaining(opts)
+      );
+    }
+  );
+
   test("initDevices() rejection propagates and leaves state at 'initializing'", async () => {
     mediaManager.initializeShouldThrow = new Error("getUserMedia failed");
     const { callbacks, recorder } = buildSpyCallbacks();

--- a/tests/src/transports/webSocket.spec.ts
+++ b/tests/src/transports/webSocket.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Characterization tests for WebSocketTransport's initDevices() contract.
+ * Locks in today's behavior ahead of Plan A step 2.
+ */
+
+import { WebSocketTransport } from "@pipecat-ai/websocket-transport";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createFakeMediaManager } from "../helpers/fakeMediaManager";
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+describe("WebSocketTransport.initDevices() — characterization", () => {
+  let mediaManager: ReturnType<typeof createFakeMediaManager>;
+  let transport: WebSocketTransport;
+
+  beforeEach(() => {
+    mediaManager = createFakeMediaManager();
+    transport = new WebSocketTransport({
+      mediaManager: mediaManager as never,
+    });
+  });
+
+  test("initial state after construction is 'disconnected'", () => {
+    expect(transport.state).toBe("disconnected");
+  });
+
+  test("happy-path initDevices(): disconnected → initializing → initialized", async () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+
+    expect(mediaManager.initializeCallCount).toBe(1);
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual(["initializing", "initialized"]);
+  });
+
+  test("repeated initDevices() calls re-enter 'initializing' each time (NOT idempotent at the transport layer)", async () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+    await transport.initDevices();
+
+    expect(mediaManager.initializeCallCount).toBe(2);
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual([
+      "initializing",
+      "initialized",
+      "initializing",
+      "initialized",
+    ]);
+  });
+
+  test("initDevices() rejection propagates and leaves state at 'initializing'", async () => {
+    mediaManager.initializeShouldThrow = new Error("wav init failed");
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await expect(transport.initDevices()).rejects.toThrow("wav init failed");
+    expect(transport.state).toBe("initializing");
+    expect(recorder.states).toEqual(["initializing"]);
+  });
+});

--- a/tests/src/transports/webSocket.spec.ts
+++ b/tests/src/transports/webSocket.spec.ts
@@ -52,6 +52,24 @@ describe("WebSocketTransport.initDevices() — characterization", () => {
     ]);
   });
 
+  test.each([
+    [{ enableMic: true, enableCam: false }],
+    [{ enableMic: false, enableCam: false }],
+    [{ enableMic: true, enableCam: true }],
+    [{ enableMic: false, enableCam: true }],
+  ])(
+    "initialize(%j) forwards enableMic/enableCam through to mediaManager.setClientOptions",
+    (opts) => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks, opts);
+
+      expect(mediaManager.setClientOptions).toHaveBeenCalledTimes(1);
+      expect(mediaManager.setClientOptions).toHaveBeenCalledWith(
+        expect.objectContaining(opts)
+      );
+    }
+  );
+
   test("initDevices() rejection propagates and leaves state at 'initializing'", async () => {
     mediaManager.initializeShouldThrow = new Error("wav init failed");
     const { callbacks, recorder } = buildSpyCallbacks();

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "vitest.config.ts"]
+}

--- a/tests/vitest.config.ts
+++ b/tests/vitest.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    globals: false,
+    include: ["src/**/*.spec.ts"],
+  },
+  resolve: {
+    // Resolve each transport workspace to its source entry so vitest compiles
+    // TypeScript directly rather than pulling from each package's `dist`. Keeps
+    // characterization tests in lockstep with source and avoids a build step.
+    alias: {
+      "@pipecat-ai/daily-transport": new URL(
+        "../transports/daily/src/index.ts",
+        import.meta.url
+      ).pathname,
+      "@pipecat-ai/small-webrtc-transport": new URL(
+        "../transports/small-webrtc-transport/src/index.ts",
+        import.meta.url
+      ).pathname,
+      "@pipecat-ai/websocket-transport": new URL(
+        "../transports/websocket-transport/src/index.ts",
+        import.meta.url
+      ).pathname,
+      "@pipecat-ai/openai-realtime-webrtc-transport": new URL(
+        "../transports/openai-realtime-webrtc-transport/src/index.ts",
+        import.meta.url
+      ).pathname,
+      "@pipecat-ai/gemini-live-websocket-transport": new URL(
+        "../transports/gemini-live-websocket-transport/src/index.ts",
+        import.meta.url
+      ).pathname,
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Plan A, step 1 (part 2 of 2). Adds a shared vitest test workspace and per-transport characterization specs ahead of the `MediaState` refactor in step 2. Companion to [pipecat-client-web#202](https://github.com/pipecat-ai/pipecat-client-web/pull/202).

Context: [Pipecat: Fixing the Device Picker Spinner After Disconnect](https://www.notion.so/dailyco/Pipecat-Fixing-the-Device-Picker-Spinner-After-Disconnect-3488fc5824d0810cb7ced697f3956ee6).

### New `tests/` workspace

- Added to root `workspaces` array; root `npm run test` delegates to `vitest run` in this workspace.
- `vitest.config.ts` aliases each transport package name to its `src` entry so characterization rides source, not dist.
- Uses `happy-dom` for the DOM environment.

### Shared helpers (`tests/src/helpers`)

- `observeTransport.ts`: builds a full spy-backed `RTVIEventCallbacks`, exposes a `StateRecorder` that captures every `onTransportStateChanged` emission, and wires a transport like `PipecatClient` does.
- `fakeMediaManager.ts`: structural MediaManager double for the DI-friendly transports (SmallWebRTC, WebSocket, Gemini Live). Tracks `initializeCallCount` and supports `initializeShouldThrow`.
- `fakeDaily.ts`: daily-js call-object stub covering the slice used by DailyTransport + OpenAIRealTimeWebRTCTransport during `initialize()` and `initDevices()`.

### Per-transport specs (5 files, 25 tests)

Each transport gets:
- initial state is `"disconnected"`
- happy-path `initDevices()` transitions (`disconnected` → `initializing` → `initialized`)
- repeated calls re-enter `"initializing"` (NOT idempotent at the transport layer)
- rejection leaves state at `"initializing"`

Daily and OpenAI additionally cover:
- fan-out of `onAvailable*Updated` / `on*Updated` exactly once per call
- partial internal idempotency around the audio-level observers (they guard restart via `isLocalAudioLevelObserverRunning`) — step 2 should preserve this when it short-circuits repeat calls at the client layer

No production code changes. No transport behavior is modified.

## Test plan

- [x] `npm run test` at repo root — all 25 tests pass across 5 spec files
- [x] `npx tsc --noEmit` in `tests/` — clean