### PR TITLE
fix: persist enableMic/enableCam across the pre-session boundary

### DIFF
--- a/tests/src/helpers/fakeDaily.ts
+++ b/tests/src/helpers/fakeDaily.ts
@@ -15,11 +15,27 @@ export interface FakeDailyCallObject {
   isRemoteParticipantsAudioLevelObserverRunning: Mock;
   startLocalAudioLevelObserver: Mock;
   startRemoteParticipantsAudioLevelObserver: Mock;
+  participants: Mock;
+  setLocalAudio: Mock;
+  setLocalVideo: Mock;
+  localAudio: Mock;
+  localVideo: Mock;
+  setJoined: (joined: boolean) => void;
   startCameraCallCount: number;
   startCameraShouldThrow?: Error;
 }
 
 export function createFakeDailyCallObject(): FakeDailyCallObject {
+  // Tracks whether the call has been "joined" — used by participants() so
+  // tests can model the pre-session vs post-join boundary that
+  // enableMic/enableCam now guards on.
+  let joined = false;
+  // Tracks last-applied audio/video state, mirrored by setLocalAudio /
+  // setLocalVideo so localAudio() / localVideo() can return realistic
+  // values once the call is joined.
+  let audioOn = true;
+  let videoOn = false;
+
   const fake: FakeDailyCallObject = {
     startCameraCallCount: 0,
     startCameraShouldThrow: undefined,
@@ -31,6 +47,18 @@ export function createFakeDailyCallObject(): FakeDailyCallObject {
     isRemoteParticipantsAudioLevelObserverRunning: vi.fn(() => false),
     startLocalAudioLevelObserver: vi.fn(async () => {}),
     startRemoteParticipantsAudioLevelObserver: vi.fn(async () => {}),
+    participants: vi.fn(() => (joined ? { local: { id: "local-1" } } : {})),
+    setLocalAudio: vi.fn((enable: boolean) => {
+      audioOn = enable;
+    }),
+    setLocalVideo: vi.fn((enable: boolean) => {
+      videoOn = enable;
+    }),
+    localAudio: vi.fn(() => audioOn),
+    localVideo: vi.fn(() => videoOn),
+    setJoined: (next: boolean) => {
+      joined = next;
+    },
   };
 
   // Close over `fake` rather than binding `this` — vitest loses its Mock

--- a/tests/src/transports/dailyEnable.spec.ts
+++ b/tests/src/transports/dailyEnable.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Characterization tests for DailyTransport.enableMic / enableCam under
+ * Plan B2: pre-session toggles are remembered for the next session, and
+ * applied live only when the call is joined.
+ *
+ * Pre-fix, both methods called setLocalAudio / setLocalVideo
+ * unconditionally — pre-session calls silently no-opped at the daily-js
+ * layer AND nothing was stored, so the next connect() lost the change.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  createFakeDailyCallObject,
+  type FakeDailyCallObject,
+} from "../helpers/fakeDaily";
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+let currentFakeDaily: FakeDailyCallObject | null = null;
+
+vi.mock("@daily-co/daily-js", () => ({
+  default: {
+    createCallObject: () => currentFakeDaily,
+  },
+}));
+
+const { DailyTransport } = await import("@pipecat-ai/daily-transport");
+
+describe("DailyTransport.enableMic — characterization", () => {
+  let fakeDaily: FakeDailyCallObject;
+  let transport: InstanceType<typeof DailyTransport>;
+
+  beforeEach(() => {
+    fakeDaily = createFakeDailyCallObject();
+    currentFakeDaily = fakeDaily;
+    transport = new DailyTransport();
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+  });
+
+  test("pre-session enableMic(false) does NOT call setLocalAudio (call not joined yet)", () => {
+    transport.enableMic(false);
+
+    expect(fakeDaily.setLocalAudio).not.toHaveBeenCalled();
+  });
+
+  test("pre-session enableMic(false) IS remembered for the next session via startCamera({ startAudioOff: true })", async () => {
+    transport.enableMic(false);
+
+    await transport.initDevices();
+
+    expect(fakeDaily.startCamera).toHaveBeenCalledWith(
+      expect.objectContaining({ startAudioOff: true })
+    );
+  });
+
+  test("pre-session enableMic(true) flips startAudioOff back to false on the next session", async () => {
+    transport.enableMic(false);
+    transport.enableMic(true);
+
+    await transport.initDevices();
+
+    expect(fakeDaily.startCamera).toHaveBeenCalledWith(
+      expect.objectContaining({ startAudioOff: false })
+    );
+  });
+
+  test("post-join enableMic(false) IS applied live via setLocalAudio", () => {
+    fakeDaily.setJoined(true);
+
+    transport.enableMic(false);
+
+    expect(fakeDaily.setLocalAudio).toHaveBeenCalledTimes(1);
+    expect(fakeDaily.setLocalAudio).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("DailyTransport.enableCam — characterization", () => {
+  let fakeDaily: FakeDailyCallObject;
+  let transport: InstanceType<typeof DailyTransport>;
+
+  beforeEach(() => {
+    fakeDaily = createFakeDailyCallObject();
+    currentFakeDaily = fakeDaily;
+    transport = new DailyTransport();
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+  });
+
+  test("pre-session enableCam(true) does NOT call setLocalVideo", () => {
+    transport.enableCam(true);
+
+    expect(fakeDaily.setLocalVideo).not.toHaveBeenCalled();
+  });
+
+  test("pre-session enableCam(true) IS remembered for the next session via startCamera({ startVideoOff: false })", async () => {
+    transport.enableCam(true);
+
+    await transport.initDevices();
+
+    expect(fakeDaily.startCamera).toHaveBeenCalledWith(
+      expect.objectContaining({ startVideoOff: false })
+    );
+  });
+
+  test("post-join enableCam(true) IS applied live via setLocalVideo", () => {
+    fakeDaily.setJoined(true);
+
+    transport.enableCam(true);
+
+    expect(fakeDaily.setLocalVideo).toHaveBeenCalledTimes(1);
+    expect(fakeDaily.setLocalVideo).toHaveBeenCalledWith(true);
+  });
+});

--- a/tests/src/transports/openaiEnable.spec.ts
+++ b/tests/src/transports/openaiEnable.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Characterization tests for OpenAIRealTimeWebRTCTransport.enableMic /
+ * enableCam under Plan B2: pre-session toggles are remembered for the
+ * next session, and applied live only when the call is joined.
+ *
+ * Pre-fix, the methods guarded with `if (!this._daily.participants()?.local) return;`
+ * which silently dropped pre-session calls AND nothing was stored, so
+ * the next initDevices() lost the change.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  createFakeDailyCallObject,
+  type FakeDailyCallObject,
+} from "../helpers/fakeDaily";
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+let currentFakeDaily: FakeDailyCallObject | null = null;
+
+vi.mock("@daily-co/daily-js", () => ({
+  default: {
+    createCallObject: () => currentFakeDaily,
+    getCallInstance: () => null,
+  },
+}));
+
+class FakeRTCDataChannel {
+  addEventListener = vi.fn();
+  send = vi.fn();
+  close = vi.fn();
+}
+
+class FakeRTCPeerConnection {
+  ontrack: unknown = null;
+  addTransceiver = vi.fn();
+  addEventListener = vi.fn();
+  createDataChannel = vi.fn(() => new FakeRTCDataChannel());
+  close = vi.fn();
+}
+(globalThis as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
+  FakeRTCPeerConnection;
+
+const { OpenAIRealTimeWebRTCTransport } = await import(
+  "@pipecat-ai/openai-realtime-webrtc-transport"
+);
+
+describe("OpenAIRealTimeWebRTCTransport.enableMic — characterization", () => {
+  let fakeDaily: FakeDailyCallObject;
+  let transport: InstanceType<typeof OpenAIRealTimeWebRTCTransport>;
+
+  beforeEach(() => {
+    fakeDaily = createFakeDailyCallObject();
+    currentFakeDaily = fakeDaily;
+    transport = new OpenAIRealTimeWebRTCTransport({ api_key: "test-key" });
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+  });
+
+  test("pre-session enableMic(false) does NOT call setLocalAudio (call not joined yet)", () => {
+    transport.enableMic(false);
+
+    expect(fakeDaily.setLocalAudio).not.toHaveBeenCalled();
+  });
+
+  test("pre-session enableMic(false) IS remembered for the next session via startCamera({ startAudioOff: true })", async () => {
+    transport.enableMic(false);
+
+    await transport.initDevices();
+
+    expect(fakeDaily.startCamera).toHaveBeenCalledWith(
+      expect.objectContaining({ startAudioOff: true })
+    );
+  });
+
+  test("post-join enableMic(false) IS applied live via setLocalAudio", () => {
+    fakeDaily.setJoined(true);
+
+    transport.enableMic(false);
+
+    expect(fakeDaily.setLocalAudio).toHaveBeenCalledTimes(1);
+    expect(fakeDaily.setLocalAudio).toHaveBeenCalledWith(false);
+  });
+
+  test("isMicEnabled pre-session reflects the stored preference, not daily-js's live state", () => {
+    transport.enableMic(false);
+
+    // Pre-fix: daily.localAudio() returned a stale/default value before
+    // the call joined, hiding the user's intent. Now the getter falls
+    // back to the stored preference.
+    expect(transport.isMicEnabled).toBe(false);
+  });
+
+  test("isMicEnabled post-join reflects daily-js's live state", () => {
+    fakeDaily.setJoined(true);
+
+    transport.enableMic(false);
+
+    expect(transport.isMicEnabled).toBe(false);
+  });
+
+  test("a user's enableMic preference survives _disconnect's reset (re-initialize)", () => {
+    // _disconnect() calls initialize(this._options, ...) again as a reset
+    // hook. The first version of this fix re-derived _micEnabled from
+    // options on every initialize(), which clobbered the user's most
+    // recent toggle on reconnect (caught by Copilot review on PR #114).
+    // After the gate, the second initialize() must NOT overwrite the
+    // stored preference.
+    transport.enableMic(false);
+    // Simulate _disconnect's re-init. PipecatClientOptions still has
+    // enableMic: true (the original construction value).
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    // Run initDevices again to observe what startCamera receives.
+    void transport.initDevices();
+
+    expect(fakeDaily.startCamera).toHaveBeenLastCalledWith(
+      expect.objectContaining({ startAudioOff: true })
+    );
+  });
+});
+
+describe("OpenAIRealTimeWebRTCTransport.enableCam — characterization", () => {
+  let fakeDaily: FakeDailyCallObject;
+  let transport: InstanceType<typeof OpenAIRealTimeWebRTCTransport>;
+
+  beforeEach(() => {
+    fakeDaily = createFakeDailyCallObject();
+    currentFakeDaily = fakeDaily;
+    transport = new OpenAIRealTimeWebRTCTransport({ api_key: "test-key" });
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+  });
+
+  test("pre-session enableCam(true) does NOT call setLocalVideo", () => {
+    transport.enableCam(true);
+
+    expect(fakeDaily.setLocalVideo).not.toHaveBeenCalled();
+  });
+
+  test("startCamera always passes startVideoOff: true regardless of enableCam (locked-in OpenAI quirk)", async () => {
+    // OpenAI is audio-only today; the transport hardcodes startVideoOff
+    // in initDevices(). Storing _camEnabled is forward-looking but does
+    // not yet alter the startCamera call. Lock this in so a future
+    // change is deliberate.
+    transport.enableCam(true);
+
+    await transport.initDevices();
+
+    expect(fakeDaily.startCamera).toHaveBeenCalledWith(
+      expect.objectContaining({ startVideoOff: true })
+    );
+  });
+
+  test("post-join enableCam(true) IS applied live via setLocalVideo", () => {
+    fakeDaily.setJoined(true);
+
+    transport.enableCam(true);
+
+    expect(fakeDaily.setLocalVideo).toHaveBeenCalledTimes(1);
+    expect(fakeDaily.setLocalVideo).toHaveBeenCalledWith(true);
+  });
+
+  test("isCamEnabled pre-session reflects the stored preference", () => {
+    transport.enableCam(true);
+
+    expect(transport.isCamEnabled).toBe(true);
+  });
+});

--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -324,7 +324,15 @@ export class DailyTransport extends Transport {
   }
 
   enableMic(enable: boolean) {
-    this._daily.setLocalAudio(enable);
+    // Persist the caller's preference so a subsequent connect() picks it
+    // up via initDevices()'s startCamera({ startAudioOff }) call. Without
+    // this, pre-session toggles were silently lost. Apply live only when
+    // joined — pre-session, daily-js can't act on the request because the
+    // call object isn't part of a meeting yet.
+    this._dailyFactoryOptions.startAudioOff = !enable;
+    if (this._daily.participants()?.local) {
+      this._daily.setLocalAudio(enable);
+    }
   }
 
   get isMicEnabled() {
@@ -332,7 +340,10 @@ export class DailyTransport extends Transport {
   }
 
   enableCam(enable: boolean) {
-    this._daily.setLocalVideo(enable);
+    this._dailyFactoryOptions.startVideoOff = !enable;
+    if (this._daily.participants()?.local) {
+      this._daily.setLocalVideo(enable);
+    }
   }
 
   get isCamEnabled() {

--- a/transports/openai-realtime-webrtc-transport/src/OpenAIRealTimeWebRTCTransport.ts
+++ b/transports/openai-realtime-webrtc-transport/src/OpenAIRealTimeWebRTCTransport.ts
@@ -106,6 +106,21 @@ export class OpenAIRealTimeWebRTCTransport extends Transport {
   private _selectedMic: MediaDeviceInfo | Record<string, never> = {};
   private _selectedSpeaker: MediaDeviceInfo | Record<string, never> = {};
 
+  // Caller's most recent enableMic/enableCam preference. Initialized from
+  // PipecatClientOptions on the first initialize() call and updated by
+  // enableMic/enableCam calls. Used by initDevices()'s startCamera() so a
+  // pre-session toggle is honored when the call actually starts. Without
+  // this, late mutations were silently lost.
+  private _micEnabled: boolean = true;
+  private _camEnabled: boolean = false;
+
+  // Tracks whether initialize() has run at least once. _disconnect() calls
+  // initialize() again as a reset hook; on that re-run we must NOT re-derive
+  // _micEnabled / _camEnabled from the original options, or the user's most
+  // recent enable* preference would be silently overwritten on reconnect
+  // (caught by Copilot review on PR #114).
+  private _initializedOnce: boolean = false;
+
   declare private _botIsReadyResolve: {
     resolve: (value: void | PromiseLike<void>) => void;
     reject: (reason?: any) => void;
@@ -125,6 +140,15 @@ export class OpenAIRealTimeWebRTCTransport extends Transport {
     this._options = options;
     this._callbacks = options.callbacks ?? {};
     this._onMessage = messageHandler;
+
+    // Only seed enable-state from options on the very first initialize().
+    // Subsequent runs (triggered by _disconnect's reset hook) must preserve
+    // the user's most recent enable* preference.
+    if (!this._initializedOnce) {
+      this._micEnabled = options.enableMic ?? true;
+      this._camEnabled = options.enableCam === true;
+      this._initializedOnce = true;
+    }
 
     this._openai_cxn = new RTCPeerConnection();
 
@@ -154,8 +178,8 @@ export class OpenAIRealTimeWebRTCTransport extends Transport {
     this.state = "initializing";
 
     const infos = await this._daily.startCamera({
-      startVideoOff: true, // !(this._options.enableCam == true),
-      startAudioOff: !(this._options.enableMic ?? true),
+      startVideoOff: true, // !this._camEnabled — kept hardcoded; OpenAI is audio-only today
+      startAudioOff: !this._micEnabled,
       dailyConfig: { useDevicePreferenceCookies: true },
     });
     const { devices } = await this._daily.enumerateDevices();
@@ -303,18 +327,38 @@ export class OpenAIRealTimeWebRTCTransport extends Transport {
   }
 
   enableMic(enable: boolean): void {
-    if (!this._daily.participants()?.local) return;
-    this._daily.setLocalAudio(enable);
+    // Persist the caller's preference so a subsequent connect() picks it
+    // up via initDevices()'s startCamera({ startAudioOff }) call. Without
+    // this, pre-session toggles were silently lost. Apply live only when
+    // joined — pre-session, daily-js can't act on the request because the
+    // call object isn't part of a meeting yet.
+    this._micEnabled = enable;
+    if (this._daily.participants()?.local) {
+      this._daily.setLocalAudio(enable);
+    }
   }
   enableCam(enable: boolean): void {
-    if (!this._daily.participants()?.local) return;
-    this._daily.setLocalVideo(enable);
+    // OpenAI's startCamera is hardcoded to startVideoOff: true (see
+    // initDevices), so toggling cam pre-session won't actually enable
+    // video on connect today. Storing the preference anyway keeps the
+    // path symmetric with enableMic, and the transport is ready for the
+    // day OpenAI gains video support.
+    this._camEnabled = enable;
+    if (this._daily.participants()?.local) {
+      this._daily.setLocalVideo(enable);
+    }
   }
 
   get isCamEnabled(): boolean {
+    // Pre-session, daily-js's localVideo() reflects no live track and
+    // doesn't represent the caller's intent. Fall back to the stored
+    // preference so callers see a stable answer across the
+    // pre/post-join boundary.
+    if (!this._daily.participants()?.local) return this._camEnabled;
     return this._daily.localVideo();
   }
   get isMicEnabled(): boolean {
+    if (!this._daily.participants()?.local) return this._micEnabled;
     return this._daily.localAudio();
   }
 


### PR DESCRIPTION
## Summary

Plan B2. Pre-session calls to `enableMic` / `enableCam` on Daily and OpenAI transports were silently dropped:
- `setLocalAudio` / `setLocalVideo` on a daily call object that hasn't joined a meeting is a no-op.
- Neither transport stored the requested preference.

The next `initDevices()` → `startCamera()` call used the original `options.enableMic` / `options.enableCam` from construction rather than the user's most recent toggle. So a "start with mic muted" toggle on a lobby UI was lost between click and connect.

Context: [Pipecat: Fixing the Device Picker Spinner After Disconnect](https://www.notion.so/dailyco/Pipecat-Fixing-the-Device-Picker-Spinner-After-Disconnect-3488fc5824d0810cb7ced697f3956ee6) (Plan B2).

## Fix

Store the caller's preference; apply via `setLocalAudio` / `setLocalVideo` only when the call is joined. The stored value flows into the next `startCamera()` so a pre-session toggle takes effect on connect.

- **Daily transport** writes `enable*` updates back into `_dailyFactoryOptions.startAudioOff` / `startVideoOff`, which `initDevices()` already passes to `startCamera()`. No new fields.
- **OpenAI transport** adds private `_micEnabled` / `_camEnabled` fields, used by `initDevices()`'s `startCamera` and by `isMicEnabled` / `isCamEnabled` getters as a pre-session fallback (so the getters reflect intent rather than daily-js's stale pre-join state).
- **OpenAI** keeps `startVideoOff: true` hardcoded in `startCamera` (OpenAI is audio-only today). Storing `_camEnabled` is forward-looking and characterized in tests so any future change is deliberate.

## Out of scope

| Transport | Why unchanged |
|---|---|
| SmallWebRTC, Gemini | Delegate to `DailyMediaManager.enableMic` / `enableCam`, which already does the "store + apply when joined" thing correctly. |
| WebSocket (mic) | Same — via `DailyMediaManager`. |
| WebSocket (cam) | Already throws `UnsupportedFeatureError` (correct — no video). |

## Design note: silent defer instead of `DeviceError`

The Plan B2 design entry recommended "emit `DeviceError` or throw when not joined." This PR goes with the silent store-and-defer pattern instead because:

1. It matches what `DailyMediaManager` already does for the three other transports.
2. Pre-session toggles on a lobby UI ("start with mic muted") are normal user behavior. Surfacing an error every click would be noisy and there's no `DeviceErrorType` that cleanly fits "transport not joined" — the existing types all describe browser/OS-level device problems.
3. The actual bug was that *state was lost*, not that the user didn't know it was a no-op. Storing the preference fixes the symptom directly.

If a caller really needs to distinguish "applied live" from "deferred," they can check transport state. Worth flagging if reviewers disagree.

## Tests

Two new spec files in the `tests/` workspace covering both transports:

- `dailyEnable.spec.ts` (7 tests) — pre-session vs post-join behavior for `enableMic` and `enableCam`.
- `openaiEnable.spec.ts` (9 tests) — same plus the `isMicEnabled` / `isCamEnabled` getter fallback and the locked-in `startVideoOff: true` quirk.

Updated `fakeDaily.ts` to support `participants()`, `setLocalAudio` / `setLocalVideo`, `localAudio` / `localVideo`, and a `setJoined(boolean)` toggle so tests can model the pre/post-join boundary.

Full suite: **61 / 61 pass** (45 from step-1 characterization + 16 new).

## Test plan

- [x] `npm run test` — 61 / 61
- [x] `npm run build` — all five transports build clean
- [x] Manual verification: in voice-ui-kit playground, toggle mic off pre-`connect()`, then `connect()` — mic should join muted. Same for cam on Daily.

## Plan A / B status

- Plan A steps 1–3 merged; step 4 ([voice-ui-kit#134](https://github.com/pipecat-ai/voice-ui-kit/pull/134)) in review.
- Plan B1 (stale enable-state in `client-react` after disconnect) and B3 (per-transport device-management consolidation) remain as separate workstreams.