### PR TITLE
fix(ci): use paths_released to gate publish jobs in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
 
   publish-daily:
     needs: release-please
-    if: ${{ contains(fromJson(needs.release-please.outputs.paths_released), 'transports/daily') }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' && contains(fromJson(needs.release-please.outputs.paths_released), 'transports/daily') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,7 +47,7 @@ jobs:
 
   publish-gemini:
     needs: release-please
-    if: ${{ contains(fromJson(needs.release-please.outputs.paths_released), 'transports/gemini-live-websocket-transport') }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' && contains(fromJson(needs.release-please.outputs.paths_released), 'transports/gemini-live-websocket-transport') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -65,7 +65,7 @@ jobs:
 
   publish-openai:
     needs: release-please
-    if: ${{ contains(fromJson(needs.release-please.outputs.paths_released), 'transports/openai-realtime-webrtc-transport') }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' && contains(fromJson(needs.release-please.outputs.paths_released), 'transports/openai-realtime-webrtc-transport') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,7 +83,7 @@ jobs:
 
   publish-small-webrtc:
     needs: release-please
-    if: ${{ contains(fromJson(needs.release-please.outputs.paths_released), 'transports/small-webrtc-transport') }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' && contains(fromJson(needs.release-please.outputs.paths_released), 'transports/small-webrtc-transport') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,7 +101,7 @@ jobs:
 
   publish-websocket:
     needs: release-please
-    if: ${{ contains(fromJson(needs.release-please.outputs.paths_released), 'transports/websocket-transport') }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' && contains(fromJson(needs.release-please.outputs.paths_released), 'transports/websocket-transport') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
+      paths_released: ${{ steps.release.outputs.paths_released }}
       daily_release_created: ${{ steps.release.outputs['daily-transport--release_created'] }}
       gemini_release_created: ${{ steps.release.outputs['gemini-live-websocket-transport--release_created'] }}
       openai_release_created: ${{ steps.release.outputs['openai-realtime-webrtc-transport--release_created'] }}
@@ -28,7 +29,7 @@ jobs:
 
   publish-daily:
     needs: release-please
-    if: ${{ needs.release-please.outputs.daily_release_created == 'true' }}
+    if: ${{ contains(fromJson(needs.release-please.outputs.paths_released), 'transports/daily') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,7 +47,7 @@ jobs:
 
   publish-gemini:
     needs: release-please
-    if: ${{ needs.release-please.outputs.gemini_release_created == 'true' }}
+    if: ${{ contains(fromJson(needs.release-please.outputs.paths_released), 'transports/gemini-live-websocket-transport') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,7 +65,7 @@ jobs:
 
   publish-openai:
     needs: release-please
-    if: ${{ needs.release-please.outputs.openai_release_created == 'true' }}
+    if: ${{ contains(fromJson(needs.release-please.outputs.paths_released), 'transports/openai-realtime-webrtc-transport') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,7 +83,7 @@ jobs:
 
   publish-small-webrtc:
     needs: release-please
-    if: ${{ needs.release-please.outputs.small_webrtc_release_created == 'true' }}
+    if: ${{ contains(fromJson(needs.release-please.outputs.paths_released), 'transports/small-webrtc-transport') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -100,7 +101,7 @@ jobs:
 
   publish-websocket:
     needs: release-please
-    if: ${{ needs.release-please.outputs.websocket_release_created == 'true' }}
+    if: ${{ contains(fromJson(needs.release-please.outputs.paths_released), 'transports/websocket-transport') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

The release-please workflow gated each publish job on a per-component output like `daily-transport--release_created`. These outputs are not reliably emitted when release-please processes multiple components in a single run. This caused publish jobs to be skipped even when release-please had just created a release for that component.

## Fix

Added `paths_released` to the `release-please` job's `outputs:` block and updated every publish job's `if:` condition to use `contains(fromJson(needs.release-please.outputs.paths_released), '<path>')`. The `paths_released` output is a JSON array of every package path released in the run, so it is always populated when a release occurs.

See: https://github.com/googleapis/release-please-action#outputs

## Jobs updated

- `publish-daily`: `transports/daily`
- `publish-gemini`: `transports/gemini-live-websocket-transport`
- `publish-openai`: `transports/openai-realtime-webrtc-transport`
- `publish-small-webrtc`: `transports/small-webrtc-transport`
- `publish-websocket`: `transports/websocket-transport`

The old per-component outputs are left in place (no removals) to avoid breaking anything that may reference them elsewhere.