### PR TITLE
ci: allow manual dispatch of release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds `workflow_dispatch:` to the release-please workflow's `on:` triggers. This lets us re-run release-please from the Actions tab when a release PR gets stuck (e.g. due to conflicts), without needing to push a new conventional commit.