### PR TITLE
Adding support for `DailyTransport` to receive audio faster than real time.

### DIFF
--- a/lib/wavtools/index.js
+++ b/lib/wavtools/index.js
@@ -3,9 +3,11 @@ import { AudioAnalysis } from "./lib/analysis/audio_analysis.js";
 import { WavStreamPlayer } from "./lib/wav_stream_player.js";
 import { WavRecorder } from "./lib/wav_recorder.js";
 import { MediaStreamRecorder } from "./lib/mediastream_recorder.js";
+import { CaptureProcessorSrc } from "./lib/worklets/capture_processor.js";
 
 export {
   AudioAnalysis,
+  CaptureProcessorSrc,
   MediaStreamRecorder,
   WavPacker,
   WavStreamPlayer,

--- a/lib/wavtools/lib/wav_stream_player.js
+++ b/lib/wavtools/lib/wav_stream_player.js
@@ -8,17 +8,19 @@ import { AudioAnalysis } from "./analysis/audio_analysis.js";
 export class WavStreamPlayer {
   /**
    * Creates a new WavStreamPlayer instance
-   * @param {{sampleRate?: number}} options
+   * @param {{sampleRate?: number, outputToSpeakers?: boolean}} options
    * @returns {WavStreamPlayer}
    */
-  constructor({ sampleRate = 44100 } = {}) {
+  constructor({ sampleRate = 44100, outputToSpeakers = true } = {}) {
     this.scriptSrc = StreamProcessorSrc;
     this.sampleRate = sampleRate;
+    this.outputToSpeakers = outputToSpeakers;
     this.context = null;
     this.stream = null;
     this.analyser = null;
     this.trackSampleOffsets = {};
     this.interruptedTrackIds = {};
+    this._mediaStreamDestination = null;
   }
 
   /**
@@ -43,6 +45,11 @@ export class WavStreamPlayer {
     analyser.fftSize = 8192;
     analyser.smoothingTimeConstant = 0.1;
     this.analyser = analyser;
+    // Only needed when audio is not routed to speakers directly — creates a
+    // MediaStreamTrack the caller can play via an <audio> element instead.
+    if (!this.outputToSpeakers) {
+      this._mediaStreamDestination = this.context.createMediaStreamDestination();
+    }
     return true;
   }
 
@@ -92,13 +99,28 @@ export class WavStreamPlayer {
   }
 
   /**
+   * Returns the MediaStreamTrack produced by this player, available immediately
+   * after connect(). The track's sample rate matches the sampleRate passed to
+   * the constructor. Returns null if connect() has not been called yet.
+   * @returns {MediaStreamTrack|null}
+   */
+  get outputTrack() {
+    return this._mediaStreamDestination?.stream.getAudioTracks()[0] ?? null;
+  }
+
+  /**
    * Starts audio streaming
    * @private
    * @returns {Promise<true>}
    */
   _start() {
     const streamNode = new AudioWorkletNode(this.context, "stream_processor");
-    streamNode.connect(this.context.destination);
+    if (this.outputToSpeakers) {
+      streamNode.connect(this.context.destination);
+    }
+    if (this._mediaStreamDestination) {
+      streamNode.connect(this._mediaStreamDestination);
+    }
     streamNode.port.onmessage = (e) => {
       const { event } = e.data;
       if (event === "stop") {

--- a/lib/wavtools/lib/worklets/capture_processor.js
+++ b/lib/wavtools/lib/worklets/capture_processor.js
@@ -15,12 +15,18 @@ class CaptureProcessor extends AudioWorkletProcessor {
     const ch = inputs[0]?.[0];
     if (ch?.length) {
       const int16 = new Int16Array(ch.length);
+      let maxAbs = 0;
       for (let i = 0; i < ch.length; i++) {
         const s = Math.max(-1, Math.min(1, ch[i]));
         int16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+        const abs = Math.abs(int16[i]);
+        if (abs > maxAbs) maxAbs = abs;
       }
+      // WebRTC injects all-zero silence between speech bursts; threshold 5
+      // matches the Python-side _is_silence() check.
+      const isSilent = maxAbs < 5;
       // Transfer the buffer to avoid a copy
-      this.port.postMessage({ event: 'chunk', int16 }, [int16.buffer]);
+      this.port.postMessage({ event: 'chunk', int16, isSilent }, [int16.buffer]);
     }
     return true;
   }

--- a/lib/wavtools/lib/worklets/capture_processor.js
+++ b/lib/wavtools/lib/worklets/capture_processor.js
@@ -1,0 +1,36 @@
+const CaptureProcessorWorklet = `
+class CaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._active = true;
+    this.port.onmessage = (e) => {
+      if (e.data.event === 'stop') {
+        this._active = false;
+      }
+    };
+  }
+
+  process(inputs) {
+    if (!this._active) return false;
+    const ch = inputs[0]?.[0];
+    if (ch?.length) {
+      const int16 = new Int16Array(ch.length);
+      for (let i = 0; i < ch.length; i++) {
+        const s = Math.max(-1, Math.min(1, ch[i]));
+        int16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+      }
+      // Transfer the buffer to avoid a copy
+      this.port.postMessage({ event: 'chunk', int16 }, [int16.buffer]);
+    }
+    return true;
+  }
+}
+
+registerProcessor('capture_processor', CaptureProcessor);
+`;
+
+const script = new Blob([CaptureProcessorWorklet], {
+  type: "application/javascript",
+});
+const src = URL.createObjectURL(script);
+export const CaptureProcessorSrc = src;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6334,7 +6334,7 @@
     },
     "transports/daily": {
       "name": "@pipecat-ai/daily-transport",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0"
@@ -6351,7 +6351,7 @@
     },
     "transports/gemini-live-websocket-transport": {
       "name": "@pipecat-ai/gemini-live-websocket-transport",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0"
@@ -6369,7 +6369,7 @@
     },
     "transports/openai-realtime-webrtc-transport": {
       "name": "@pipecat-ai/openai-realtime-webrtc-transport",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -6388,7 +6388,7 @@
     },
     "transports/small-webrtc-transport": {
       "name": "@pipecat-ai/small-webrtc-transport",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -6409,7 +6409,7 @@
     },
     "transports/websocket-transport": {
       "name": "@pipecat-ai/websocket-transport",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",

--- a/transports/daily/src/bot_audio_player.ts
+++ b/transports/daily/src/bot_audio_player.ts
@@ -1,0 +1,82 @@
+import { WavStreamPlayer } from "../../../lib/wavtools";
+import { CaptureProcessorSrc } from "../../../lib/wavtools";
+
+/**
+ * Plays bot audio delivered faster-than-realtime over WebRTC.
+ *
+ * Pipecat writes true-rate PCM (e.g. 24 kHz) into a CustomAudioSource
+ * declared at a higher rate (e.g. 48 kHz), so audio arrives ~2x faster than
+ * real-time. This class captures that track at the declared rate, converts
+ * each render quantum to Int16 via an AudioWorklet, and feeds the samples
+ * into WavStreamPlayer whose AudioContext runs at the true rate — producing
+ * a correctly-pitched MediaStreamTrack that can be played normally.
+ */
+export class BotAudioPlayer {
+  private _captureCtx: AudioContext | null = null;
+  private _captureNode: AudioWorkletNode | null = null;
+  private _wavPlayer: InstanceType<typeof WavStreamPlayer> | null = null;
+
+  /**
+   * Start capturing and playing the bot's audio track.
+   *
+   * @param track           The bot's MediaStreamTrack from Daily (declared at declaredRate).
+   * @param declaredRate    The sample rate Pipecat declared to the CustomAudioSource (e.g. 48000).
+   * @param trueRate        The actual content sample rate of the audio (e.g. 24000).
+   * @returns               A MediaStreamTrack at trueRate with correctly-pitched audio.
+   */
+  async start(
+    track: MediaStreamTrack,
+    declaredRate: number,
+    trueRate: number
+  ): Promise<MediaStreamTrack> {
+    // Playback context at true rate. outputToSpeakers:false so audio only
+    // flows to outputTrack — the caller's <audio> element plays it, avoiding
+    // double playback from both context.destination and the audio element.
+    this._wavPlayer = new WavStreamPlayer({ sampleRate: trueRate, outputToSpeakers: false });
+    await this._wavPlayer.connect();
+
+    // Capture context at declared rate. sinkId:{type:'none'} prevents any
+    // audio from reaching the speakers from this context.
+    this._captureCtx = new AudioContext({
+      sampleRate: declaredRate,
+      // @ts-expect-error -- sinkId is not in all TypeScript lib versions yet
+      sinkId: { type: "none" },
+    });
+    await this._captureCtx.audioWorklet.addModule(CaptureProcessorSrc);
+
+    const source = this._captureCtx.createMediaStreamSource(
+      new MediaStream([track])
+    );
+    this._captureNode = new AudioWorkletNode(
+      this._captureCtx,
+      "capture_processor"
+    );
+
+    // Each 128-sample render quantum arrives here as Int16 and is forwarded
+    // to WavStreamPlayer, which queues and plays it at the true rate.
+    this._captureNode.port.onmessage = (e: MessageEvent) => {
+      if (e.data.event === "chunk") {
+        this._wavPlayer?.add16BitPCM(e.data.int16 as Int16Array, "bot");
+      }
+    };
+
+    source.connect(this._captureNode);
+
+    return this._wavPlayer.outputTrack as MediaStreamTrack;
+  }
+
+  /** Clear the playback queue, mimicking the avatar stopping mid-speech. */
+  async interrupt(): Promise<void> {
+    await this._wavPlayer?.interrupt();
+  }
+
+  /** Tear down both audio contexts and release all resources. */
+  async stop(): Promise<void> {
+    this._captureNode?.port.postMessage({ event: "stop" });
+    this._captureNode?.disconnect();
+    await this._captureCtx?.close();
+    this._captureCtx = null;
+    this._captureNode = null;
+    this._wavPlayer = null;
+  }
+}

--- a/transports/daily/src/bot_audio_player.ts
+++ b/transports/daily/src/bot_audio_player.ts
@@ -23,6 +23,9 @@ export class BotAudioPlayer {
   private _totalSamplesAdded = 0;
   private _playbackStartTime: number | null = null;
   private _lastLogTime: number | null = null;
+  // Rotated after each interrupt so WavStreamPlayer's interruptedTrackIds
+  // blacklist doesn't block future utterances.
+  private _trackIdCounter = 0;
 
   /**
    * Start capturing and playing the bot's audio track.
@@ -103,7 +106,7 @@ export class BotAudioPlayer {
           this._playbackStartTime = performance.now();
         }
         this._totalSamplesAdded += int16.length;
-        this._wavPlayer?.add16BitPCM(int16, "bot");
+        this._wavPlayer?.add16BitPCM(int16, `bot-${this._trackIdCounter}`);
         this._maybeLogBufferStatus();
       }
     };
@@ -123,6 +126,7 @@ export class BotAudioPlayer {
     }
     this._totalSamplesAdded = 0;
     this._playbackStartTime = null;
+    this._trackIdCounter++; // new trackId escapes WavStreamPlayer's interruptedTrackIds blacklist
     await this._wavPlayer?.interrupt();
   }
 

--- a/transports/daily/src/bot_audio_player.ts
+++ b/transports/daily/src/bot_audio_player.ts
@@ -17,6 +17,13 @@ export class BotAudioPlayer {
   private _wavPlayer: InstanceType<typeof WavStreamPlayer> | null = null;
   private _activationElement: HTMLAudioElement | null = null;
 
+  // Buffer tracking for silence-skip logic (mirrors Python _buffer_audio logic).
+  private _trueRate = 0;
+  private _minBufferSamples = 0; // 100 ms pre-buffer at true rate
+  private _totalSamplesAdded = 0;
+  private _playbackStartTime: number | null = null;
+  private _lastLogTime: number | null = null;
+
   /**
    * Start capturing and playing the bot's audio track.
    *
@@ -38,6 +45,12 @@ export class BotAudioPlayer {
     this._activationElement.srcObject = new MediaStream([track]);
     this._activationElement.volume = 0;
     await this._activationElement.play().catch(() => {});
+
+    this._trueRate = trueRate;
+    this._minBufferSamples = Math.ceil(trueRate * 0.1); // 100 ms pre-buffer
+    this._totalSamplesAdded = 0;
+    this._playbackStartTime = null;
+    this._lastLogTime = null;
 
     // Playback context at true rate. outputToSpeakers:false so audio only
     // flows to outputTrack — the caller's <audio> element plays it, avoiding
@@ -62,11 +75,36 @@ export class BotAudioPlayer {
       "capture_processor"
     );
 
-    // Each 128-sample render quantum arrives here as Int16 and is forwarded
-    // to WavStreamPlayer, which queues and plays it at the true rate.
+    // Each 128-sample render quantum arrives here as Int16. Silence frames
+    // injected by WebRTC are discarded when the buffer is healthy so they don't
+    // accumulate faster than the drain rate (speech arrives at 2x speed, so
+    // silence queues at 2x speed too). Below the pre-buffer threshold we keep
+    // silence so playback can start smoothly — mirrors Python _buffer_audio().
     this._captureNode.port.onmessage = (e: MessageEvent) => {
       if (e.data.event === "chunk") {
-        this._wavPlayer?.add16BitPCM(e.data.int16 as Int16Array, "bot");
+        const int16 = e.data.int16 as Int16Array;
+        const isSilent = e.data.isSilent as boolean;
+
+        if (isSilent) {
+          const buffered = this._estimatedBufferedSamples();
+          if (buffered >= this._minBufferSamples) {
+            this._maybeLogBufferStatus();
+            return; // buffer is healthy — discard silence so it can drain
+          }
+          // buffer is below pre-buffer threshold — keep silence to fill it
+        }
+
+        // Reset tracking when WavStreamPlayer drained and restarted between utterances.
+        if (!this._wavPlayer?.stream) {
+          this._totalSamplesAdded = 0;
+          this._playbackStartTime = null;
+        }
+        if (this._playbackStartTime === null) {
+          this._playbackStartTime = performance.now();
+        }
+        this._totalSamplesAdded += int16.length;
+        this._wavPlayer?.add16BitPCM(int16, "bot");
+        this._maybeLogBufferStatus();
       }
     };
 
@@ -77,7 +115,34 @@ export class BotAudioPlayer {
 
   /** Clear the playback queue, mimicking the avatar stopping mid-speech. */
   async interrupt(): Promise<void> {
+    const dropped = this._estimatedBufferedSamples();
+    if (dropped > 0) {
+      console.log(
+        `[BotAudioPlayer] Interrupt — dropped ~${dropped.toFixed(0)} samples (${(dropped / this._trueRate).toFixed(3)}s)`
+      );
+    }
+    this._totalSamplesAdded = 0;
+    this._playbackStartTime = null;
     await this._wavPlayer?.interrupt();
+  }
+
+  private _estimatedBufferedSamples(): number {
+    if (this._playbackStartTime === null || this._totalSamplesAdded === 0) return 0;
+    const elapsedMs = performance.now() - this._playbackStartTime;
+    const drained = (elapsedMs / 1000) * this._trueRate;
+    return Math.max(0, this._totalSamplesAdded - drained);
+  }
+
+  private _maybeLogBufferStatus(): void {
+    const now = performance.now();
+    if (this._lastLogTime === null || now - this._lastLogTime >= 1000) {
+      const buffered = this._estimatedBufferedSamples();
+      const bufferedSeconds = buffered / this._trueRate;
+      console.log(
+        `[BotAudioPlayer] Buffer: ~${buffered.toFixed(0)} samples (${bufferedSeconds.toFixed(3)}s)`
+      );
+      this._lastLogTime = now;
+    }
   }
 
   /** Tear down both audio contexts and release all resources. */
@@ -93,5 +158,7 @@ export class BotAudioPlayer {
     this._captureCtx = null;
     this._captureNode = null;
     this._wavPlayer = null;
+    this._totalSamplesAdded = 0;
+    this._playbackStartTime = null;
   }
 }

--- a/transports/daily/src/bot_audio_player.ts
+++ b/transports/daily/src/bot_audio_player.ts
@@ -15,6 +15,7 @@ export class BotAudioPlayer {
   private _captureCtx: AudioContext | null = null;
   private _captureNode: AudioWorkletNode | null = null;
   private _wavPlayer: InstanceType<typeof WavStreamPlayer> | null = null;
+  private _activationElement: HTMLAudioElement | null = null;
 
   /**
    * Start capturing and playing the bot's audio track.
@@ -29,6 +30,15 @@ export class BotAudioPlayer {
     declaredRate: number,
     trueRate: number
   ): Promise<MediaStreamTrack> {
+    // Chrome's WebRTC audio pipeline is dormant until the track is rendered in
+    // an <audio> element. Without this, createMediaStreamSource() receives
+    // silence. We attach the original track to a silent element to activate the
+    // pipeline without any audible output.
+    this._activationElement = new Audio();
+    this._activationElement.srcObject = new MediaStream([track]);
+    this._activationElement.volume = 0;
+    await this._activationElement.play().catch(() => {});
+
     // Playback context at true rate. outputToSpeakers:false so audio only
     // flows to outputTrack — the caller's <audio> element plays it, avoiding
     // double playback from both context.destination and the audio element.
@@ -72,6 +82,11 @@ export class BotAudioPlayer {
 
   /** Tear down both audio contexts and release all resources. */
   async stop(): Promise<void> {
+    if (this._activationElement) {
+      this._activationElement.pause();
+      this._activationElement.srcObject = null;
+      this._activationElement = null;
+    }
     this._captureNode?.port.postMessage({ event: "stop" });
     this._captureNode?.disconnect();
     await this._captureCtx?.close();

--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -35,6 +35,7 @@ import {
 } from "@pipecat-ai/client-js";
 
 import { MediaStreamRecorder } from "../../../lib/wavtools";
+import { BotAudioPlayer } from "./bot_audio_player";
 
 import packageJson from "../package.json";
 
@@ -47,11 +48,19 @@ export interface DailyConnectionEndpoint {
 
 export interface DailyTransportConstructorOptions extends DailyFactoryOptions {
   bufferLocalAudioUntilBotReady?: boolean;
+  /**
+   * When true, the transport intercepts the bot's audio track and plays it
+   * through a WavStreamPlayer running at the true sample rate. This is used
+   * together with Pipecat's audio_out_declared_sample_rate feature, which
+   * delivers audio faster-than-realtime over WebRTC.
+   */
+  fasterThanRealtime?: boolean;
 }
 
 export enum DailyRTVIMessageType {
   AUDIO_BUFFERING_STARTED = "audio-buffering-started",
   AUDIO_BUFFERING_STOPPED = "audio-buffering-stopped",
+  AUDIO_FASTER_THAN_REALTIME = "audio.faster_than_realtime",
 }
 
 export type DailyEventCallbacks = RTVIEventCallbacks &
@@ -130,13 +139,23 @@ export class DailyTransport extends Transport {
   private _audioQueue: ArrayBuffer[] = [];
   declare private _mediaStreamRecorder: MediaStreamRecorder;
 
+  // Faster-than-realtime audio playback
+  private _fasterThanRealtime: boolean = false;
+  private _trueSampleRate: number = 0;
+  private _declaredSampleRate: number = 0;
+  private _botAudioPlayer: BotAudioPlayer | null = null;
+  private _botOutputTrack: MediaStreamTrack | null = null;
+  private _pendingBotTrack: MediaStreamTrack | null = null;
+  private _pendingBotParticipant: DailyParticipant | null = null;
+
   constructor(opts: DailyTransportConstructorOptions = {}) {
     super();
 
     this._callbacks = {} as DailyEventCallbacks;
 
-    const { bufferLocalAudioUntilBotReady, ...dailyOpts } = opts;
+    const { bufferLocalAudioUntilBotReady, fasterThanRealtime, ...dailyOpts } = opts;
     this._dailyFactoryOptions = dailyOpts;
+    this._fasterThanRealtime = fasterThanRealtime ?? false;
     // Enable device preference cookies by default
     if (
       typeof this._dailyFactoryOptions.dailyConfig
@@ -377,7 +396,7 @@ export class DailyTransport extends Transport {
 
     if (bot) {
       tracks.bot = {
-        audio: bot?.tracks?.audio?.persistentTrack,
+        audio: this._botOutputTrack ?? bot?.tracks?.audio?.persistentTrack,
         video: bot?.tracks?.video?.persistentTrack,
       };
     }
@@ -608,7 +627,15 @@ export class DailyTransport extends Transport {
 
     this._audioQueue = [];
     this._currentAudioTrack = null;
+    this._pendingBotTrack = null;
+    this._pendingBotParticipant = null;
+    this._botOutputTrack = null;
     this.stopRecording();
+
+    if (this._botAudioPlayer) {
+      await this._botAudioPlayer.stop();
+      this._botAudioPlayer = null;
+    }
 
     await this._daily.leave();
   }
@@ -630,6 +657,31 @@ export class DailyTransport extends Transport {
   private handleAppMessage(ev: DailyEventObjectAppMessage) {
     // Bubble any messages with rtvi-ai label
     if (ev.data.label === "rtvi-ai") {
+      if (this._fasterThanRealtime) {
+        if (ev.data.type === DailyRTVIMessageType.AUDIO_FASTER_THAN_REALTIME) {
+          this._trueSampleRate = ev.data.data.true_sample_rate as number;
+          this._declaredSampleRate = ev.data.data.declared_sample_rate as number;
+          // Bot track arrived before rates were known — set up now and fire the
+          // deferred onTrackStarted with the correctly-pitched outputTrack.
+          if (this._pendingBotTrack) {
+            const track = this._pendingBotTrack;
+            const participant = this._pendingBotParticipant;
+            this._pendingBotTrack = null;
+            this._pendingBotParticipant = null;
+            void this._setupBotAudioPlayer(track).then(() => {
+              this._callbacks.onTrackStarted?.(
+                this._botOutputTrack ?? track,
+                participant ? dailyParticipantToParticipant(participant) : undefined
+              );
+            });
+          }
+          return; // transport-internal message, don't forward
+        }
+        if (ev.data.type === "conversation.interrupt") {
+          void this._botAudioPlayer?.interrupt();
+          // Fall through to also forward the message to the app
+        }
+      }
       this._onMessage({
         id: ev.data.id,
         type: ev.data.type,
@@ -771,6 +823,30 @@ export class DailyTransport extends Transport {
       if (ev.participant?.local && ev.track.kind === "audio") {
         void this.handleLocalAudioTrack(ev.track);
       }
+
+      if (
+        this._fasterThanRealtime &&
+        !ev.participant?.local &&
+        ev.track.kind === "audio"
+      ) {
+        // Rates already known — set up the player and fire onTrackStarted with
+        // the correctly-pitched outputTrack instead of the original.
+        if (this._trueSampleRate && this._declaredSampleRate) {
+          const participant = ev.participant ?? null;
+          void this._setupBotAudioPlayer(ev.track).then(() => {
+            this._callbacks.onTrackStarted?.(
+              this._botOutputTrack ?? ev.track,
+              participant ? dailyParticipantToParticipant(participant) : undefined
+            );
+          });
+        } else {
+          // Rates not yet received — defer until audio.faster_than_realtime arrives.
+          this._pendingBotTrack = ev.track;
+          this._pendingBotParticipant = ev.participant ?? null;
+        }
+        return; // onTrackStarted is fired asynchronously above (or deferred)
+      }
+
       this._callbacks.onTrackStarted?.(
         ev.track,
         ev.participant
@@ -778,6 +854,15 @@ export class DailyTransport extends Transport {
           : undefined
       );
     }
+  }
+
+  private async _setupBotAudioPlayer(track: MediaStreamTrack): Promise<void> {
+    this._botAudioPlayer = new BotAudioPlayer();
+    this._botOutputTrack = await this._botAudioPlayer.start(
+      track,
+      this._declaredSampleRate,
+      this._trueSampleRate
+    );
   }
 
   private handleTrackStopped(ev: DailyEventObjectTrack) {

--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -156,6 +156,8 @@ export class DailyTransport extends Transport {
     const { bufferLocalAudioUntilBotReady, fasterThanRealtime, ...dailyOpts } = opts;
     this._dailyFactoryOptions = dailyOpts;
     this._fasterThanRealtime = fasterThanRealtime ?? false;
+    console.log("Faster than realtime enabled:", this._fasterThanRealtime);
+
     // Enable device preference cookies by default
     if (
       typeof this._dailyFactoryOptions.dailyConfig
@@ -669,10 +671,12 @@ export class DailyTransport extends Transport {
             this._pendingBotTrack = null;
             this._pendingBotParticipant = null;
             void this._setupBotAudioPlayer(track).then(() => {
-              this._callbacks.onTrackStarted?.(
-                this._botOutputTrack ?? track,
-                participant ? dailyParticipantToParticipant(participant) : undefined
-              );
+              if (this._botOutputTrack) {
+                this._callbacks.onTrackStarted?.(
+                  this._botOutputTrack,
+                  participant ? dailyParticipantToParticipant(participant) : undefined
+                );
+              }
             });
           }
           return; // transport-internal message, don't forward
@@ -834,10 +838,14 @@ export class DailyTransport extends Transport {
         if (this._trueSampleRate && this._declaredSampleRate) {
           const participant = ev.participant ?? null;
           void this._setupBotAudioPlayer(ev.track).then(() => {
-            this._callbacks.onTrackStarted?.(
-              this._botOutputTrack ?? ev.track,
-              participant ? dailyParticipantToParticipant(participant) : undefined
-            );
+            if (this._botOutputTrack) {
+              this._callbacks.onTrackStarted?.(
+                this._botOutputTrack,
+                participant
+                  ? dailyParticipantToParticipant(participant)
+                  : undefined
+              );
+            }
           });
         } else {
           // Rates not yet received — defer until audio.faster_than_realtime arrives.

--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -58,9 +58,8 @@ export interface DailyTransportConstructorOptions extends DailyFactoryOptions {
 }
 
 export enum DailyRTVIMessageType {
-  AUDIO_BUFFERING_STARTED = "audio-buffering-started",
-  AUDIO_BUFFERING_STOPPED = "audio-buffering-stopped",
   AUDIO_FASTER_THAN_REALTIME = "audio.faster_than_realtime",
+  USER_STARTED_SPEAKING = "user-started-speaking",
 }
 
 export type DailyEventCallbacks = RTVIEventCallbacks &
@@ -681,7 +680,8 @@ export class DailyTransport extends Transport {
           }
           return; // transport-internal message, don't forward
         }
-        if (ev.data.type === "conversation.interrupt") {
+        if (ev.data.type === DailyRTVIMessageType.USER_STARTED_SPEAKING) {
+          console.log("User started speaking");
           void this._botAudioPlayer?.interrupt();
           // Fall through to also forward the message to the app
         }


### PR DESCRIPTION
## Summary
  
- Added faster-than-realtime audio support for the Daily transport via a new `BotAudioPlayer` class — Pipecat sends true-rate PCM (e.g. 24 kHz) declared  as a higher rate (e.g. 48 kHz), so audio arrives ~2x faster than real-time; `BotAudioPlayer` captures that track at the declared rate and replays it through a `WavStreamPlayer` AudioContext running at the true rate, producing a correctly-pitched output track
- Added per-second buffer logging (`[BotAudioPlayer] Buffer: ~N samples (X.XXXs)`) and interrupt drop logging to aid debugging
- Improvements to make it work:
  - Fixed Chrome WebRTC audio pipeline not activating for Web Audio capture:
    Chrome requires a remote WebRTC track to be rendered in an `<audio>` element
    before `createMediaStreamSource()` receives audio; a hidden, volume-0 element
    now activates the pipeline without audible output
  - Fixed silence accumulation bug: WebRTC injects silence between utterances at
    the declared rate but the drain runs at the true rate, causing the buffer to
    grow unboundedly; silence frames are now discarded when the buffer is above
    a 100 ms threshold (matching the Python-side `_buffer_audio` logic), and
    kept below the threshold for pre-buffer smoothness

## Usage
  
Enable on the client side by passing `fasterThanRealtime: true` to the `DailyTransport` options: 
  
  ```ts
  const transport = new DailyTransport({
    fasterThanRealtime: true,
  });
  
On the Pipecat server side, configure the pipeline to use a declared sample rate higher than the true content rate (e.g. audio_out_declared_sample_rate=48000 with audio_out_sample_rate=24000) so audio is delivered faster than real-time over WebRTC.
  ```

## Related PRs
- Pipecat [PR](https://github.com/pipecat-ai/pipecat/pull/4544).
- New example [PR](https://github.com/pipecat-ai/pipecat-examples/pull/213).
