### PR TITLE
chore: Bump client-js dependency for all transports to 1.11.0

### DIFF
--- a/examples/directToLLMTransports/package-lock.json
+++ b/examples/directToLLMTransports/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@pipecat-ai/client-js": "^1.10.0",
+        "@pipecat-ai/client-js": "^1.11.0",
         "@pipecat-ai/gemini-live-websocket-transport": "file:../../transports/gemini-live-websocket-transport",
         "@pipecat-ai/openai-realtime-webrtc-transport": "file:../../transports/openai-realtime-webrtc-transport"
       },
@@ -21,39 +21,39 @@
     },
     "../../transports/gemini-live-websocket-transport": {
       "name": "@pipecat-ai/gemini-live-websocket-transport",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.10.0",
+        "@pipecat-ai/client-js": "^1.11.0",
         "@types/node": "^22.9.0",
         "eslint": "9.39.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.11.0"
       }
     },
     "../../transports/openai-realtime-webrtc-transport": {
       "name": "@pipecat-ai/openai-realtime-webrtc-transport",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
         "dequal": "^2.0.3"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.10.0",
+        "@pipecat-ai/client-js": "^1.11.0",
         "@types/node": "^22.9.0",
         "eslint": "9.39.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.11.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.10.0.tgz",
-      "integrity": "sha512-5V0pF1LgKlDiYA7teaDdOVtoU7EDvb4LDIAkP4xIRThL6xNB2A+4v1VxrO8qfgLEUJ6UqwakhYJIowc9wpHKAw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.11.0.tgz",
+      "integrity": "sha512-Au3mmyt+DQn49+gSaQOO+LoiOESxzr7GqSswEGAiuloOJIanqa/q9yOizD/Sl9wINr/qkcdDN2ejJOxhrh8KtQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",

--- a/examples/directToLLMTransports/package.json
+++ b/examples/directToLLMTransports/package.json
@@ -11,7 +11,7 @@
   "license": "BSD-2-Clause",
   "description": "",
   "dependencies": {
-    "@pipecat-ai/client-js": "^1.10.0",
+    "@pipecat-ai/client-js": "^1.11.0",
     "@pipecat-ai/gemini-live-websocket-transport": "file:../../transports/gemini-live-websocket-transport",
     "@pipecat-ai/openai-realtime-webrtc-transport": "file:../../transports/openai-realtime-webrtc-transport"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "peerDependencies": {
         "@daily-co/daily-js": "^0.90.0",
-        "@pipecat-ai/client-js": "^1.10.0"
+        "@pipecat-ai/client-js": "^1.11.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2668,9 +2668,9 @@
       "link": true
     },
     "node_modules/@pipecat-ai/client-js": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.10.0.tgz",
-      "integrity": "sha512-5V0pF1LgKlDiYA7teaDdOVtoU7EDvb4LDIAkP4xIRThL6xNB2A+4v1VxrO8qfgLEUJ6UqwakhYJIowc9wpHKAw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.11.0.tgz",
+      "integrity": "sha512-Au3mmyt+DQn49+gSaQOO+LoiOESxzr7GqSswEGAiuloOJIanqa/q9yOizD/Sl9wINr/qkcdDN2ejJOxhrh8KtQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",
@@ -6193,9 +6193,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6336,61 +6336,61 @@
     },
     "transports/daily": {
       "name": "@pipecat-ai/daily-transport",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.10.0",
+        "@pipecat-ai/client-js": "^1.11.0",
         "eslint": "9.39.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.11.0"
       }
     },
     "transports/gemini-live-websocket-transport": {
       "name": "@pipecat-ai/gemini-live-websocket-transport",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.10.0",
+        "@pipecat-ai/client-js": "^1.11.0",
         "@types/node": "^22.9.0",
         "eslint": "9.39.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.11.0"
       }
     },
     "transports/openai-realtime-webrtc-transport": {
       "name": "@pipecat-ai/openai-realtime-webrtc-transport",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
         "dequal": "^2.0.3"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.10.0",
+        "@pipecat-ai/client-js": "^1.11.0",
         "@types/node": "^22.9.0",
         "eslint": "9.39.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.11.0"
       }
     },
     "transports/small-webrtc-transport": {
       "name": "@pipecat-ai/small-webrtc-transport",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -6398,7 +6398,7 @@
         "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.10.0",
+        "@pipecat-ai/client-js": "^1.11.0",
         "@types/lodash": "^4.17.20",
         "@types/node": "^22.9.0",
         "eslint": "9.39.1",
@@ -6406,12 +6406,12 @@
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.11.0"
       }
     },
     "transports/websocket-transport": {
       "name": "@pipecat-ai/websocket-transport",
-      "version": "1.6.4",
+      "version": "1.6.6",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -6420,14 +6420,14 @@
         "x-law": "^0.3.1"
       },
       "devDependencies": {
-        "@pipecat-ai/client-js": "^1.10.0",
+        "@pipecat-ai/client-js": "^1.11.0",
         "@types/node": "^22.9.0",
         "eslint": "9.39.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
-        "@pipecat-ai/client-js": "~1.10.0"
+        "@pipecat-ai/client-js": "~1.11.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "peerDependencies": {
     "@daily-co/daily-js": "^0.90.0",
-    "@pipecat-ai/client-js": "^1.10.0"
+    "@pipecat-ai/client-js": "^1.11.0"
   }
 }

--- a/transports/daily/package.json
+++ b/transports/daily/package.json
@@ -28,13 +28,13 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "^1.10.0",
+    "@pipecat-ai/client-js": "^1.11.0",
     "eslint": "9.39.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~1.10.0"
+    "@pipecat-ai/client-js": "~1.11.0"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.90.0"

--- a/transports/gemini-live-websocket-transport/package.json
+++ b/transports/gemini-live-websocket-transport/package.json
@@ -31,14 +31,14 @@
     "@daily-co/daily-js": "^0.90.0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "^1.10.0",
+    "@pipecat-ai/client-js": "^1.11.0",
     "@types/node": "^22.9.0",
     "eslint": "9.39.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~1.10.0"
+    "@pipecat-ai/client-js": "~1.11.0"
   },
   "description": "Pipecat Gemini Multimodal Live Transport Package",
   "author": "Daily.co",

--- a/transports/openai-realtime-webrtc-transport/package.json
+++ b/transports/openai-realtime-webrtc-transport/package.json
@@ -28,14 +28,14 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "^1.10.0",
+    "@pipecat-ai/client-js": "^1.11.0",
     "@types/node": "^22.9.0",
     "eslint": "9.39.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~1.10.0"
+    "@pipecat-ai/client-js": "~1.11.0"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.90.0",

--- a/transports/small-webrtc-transport/package.json
+++ b/transports/small-webrtc-transport/package.json
@@ -29,7 +29,7 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "^1.10.0",
+    "@pipecat-ai/client-js": "^1.11.0",
     "@types/lodash": "^4.17.20",
     "@types/node": "^22.9.0",
     "eslint": "9.39.1",
@@ -37,7 +37,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~1.10.0"
+    "@pipecat-ai/client-js": "~1.11.0"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.90.0",

--- a/transports/websocket-transport/package.json
+++ b/transports/websocket-transport/package.json
@@ -29,14 +29,14 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@pipecat-ai/client-js": "^1.10.0",
+    "@pipecat-ai/client-js": "^1.11.0",
     "@types/node": "^22.9.0",
     "eslint": "9.39.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1"
   },
   "peerDependencies": {
-    "@pipecat-ai/client-js": "~1.10.0"
+    "@pipecat-ai/client-js": "~1.11.0"
   },
   "dependencies": {
     "@daily-co/daily-js": "^0.90.0",


### PR DESCRIPTION
Bump client-js dependency for all transports to 1.11.0