### PR TITLE
MoQ: play bot audio via @moq/watch buffered playback

### DIFF
--- a/0001-what-will-merge.patch
+++ b/0001-what-will-merge.patch
@@ -1,0 +1,13 @@
+diff --git a/package.json b/package.json
+index 046412c..0a97d1b 100644
+--- a/package.json
++++ b/package.json
+@@ -28,6 +28,7 @@
+     "typescript": "^5.5.4"
+   },
+   "peerDependencies": {
+-    "@daily-co/daily-js": "^0.90.0"
++    "@daily-co/daily-js": "^0.90.0",
++    "@pipecat-ai/client-js": "^1.10.0"
+   }
+ }

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,6 +383,7 @@
       "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.90.0.tgz",
       "integrity": "sha512-XnuuNIxLt8GOv+rFYoU+OPTSmVj+Mg9hRPK2EM6WYVY62F6rcw7vwzZBOSCisVuu1VnTIF/2J9V0VEBa83lDzw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@sentry/browser": "^8.33.1",
@@ -1054,6 +1055,7 @@
       "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.16.4",
@@ -2737,6 +2739,7 @@
       "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.11.0.tgz",
       "integrity": "sha512-Au3mmyt+DQn49+gSaQOO+LoiOESxzr7GqSswEGAiuloOJIanqa/q9yOizD/Sl9wINr/qkcdDN2ejJOxhrh8KtQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@types/events": "^3.0.3",
         "bowser": "^2.11.0",
@@ -3472,6 +3475,7 @@
       "version": "22.16.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3626,6 +3630,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3766,6 +3771,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4043,6 +4049,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4267,6 +4274,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4651,6 +4659,7 @@
       "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -4816,6 +4825,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5618,6 +5628,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5997,6 +6008,7 @@
     "node_modules/typescript": {
       "version": "5.8.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6078,6 +6090,7 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6428,6 +6441,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6439,6 +6453,7 @@
         "@pipecat-ai/client-js": "^1.7.0",
         "@pipecat-ai/daily-transport": "*",
         "@pipecat-ai/gemini-live-websocket-transport": "*",
+        "@pipecat-ai/moq-transport": "*",
         "@pipecat-ai/openai-realtime-webrtc-transport": "*",
         "@pipecat-ai/small-webrtc-transport": "*",
         "@pipecat-ai/websocket-transport": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,40 +394,6 @@
         "node": ">=22.14.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
@@ -625,6 +591,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@kixelated/libavjs-webcodecs-polyfill": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@kixelated/libavjs-webcodecs-polyfill/-/libavjs-webcodecs-polyfill-0.5.5.tgz",
+      "integrity": "sha512-Q1zgnTMMQ2F7IE9ylx3C1XzVbg5vYN18jiDINO5U3kNPBOHdYuUlJsMhtBoqr1M6ocLtoiqdHmLs7tHFgrw5KA==",
+      "license": "0BSD",
+      "dependencies": {
+        "@libav.js/types": "^6.7.7",
+        "@ungap/global-this": "^0.4.4"
+      }
+    },
     "node_modules/@lezer/common": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
@@ -641,6 +617,18 @@
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
+    },
+    "node_modules/@libav.js/types": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/@libav.js/types/-/types-6.8.8.tgz",
+      "integrity": "sha512-Lbik/0Q3x2R8cI7mOtRgt+nUWLqGXh7UinMndmpdXSDY4YEjYyVUDsq6fxkuriL78+LCYx8frZIN1r+oDsvYCQ==",
+      "license": "LGPL-2.1"
+    },
+    "node_modules/@libav.js/variant-opus-af": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/@libav.js/variant-opus-af/-/variant-opus-af-6.8.8.tgz",
+      "integrity": "sha512-8KBQyA8n5goN7lyctOaPxpcx7dapOgqKh8dWW/NAcl87AgM/WoUGSex3fFc46oCtTHYrUKEm1OmZUrtkt3Q56A==",
+      "license": "LGPL-2.1"
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
       "version": "2.8.5",
@@ -739,6 +727,83 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@moq/hang": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@moq/hang/-/hang-0.2.7.tgz",
+      "integrity": "sha512-HLPpzDLsUf1dFA1M6qJMuo3Qupbyq/aiaXagh0anTjhOIjMReTF0f34Rqz+OlDWXBD3U18sPixc/WBHCwBvc0Q==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
+        "@libav.js/variant-opus-af": "^6.8.8",
+        "@moq/loc": "^0.1.0",
+        "@moq/net": "^0.1.2",
+        "@moq/signals": "^0.1.7",
+        "@svta/cml-iso-bmff": "^1.0.0-alpha.9",
+        "zod": "^4.1.5"
+      }
+    },
+    "node_modules/@moq/loc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@moq/loc/-/loc-0.1.0.tgz",
+      "integrity": "sha512-8ouPBhoZU/vAaHCrcsi97zOw0BJX/rQbfUJ7Dx2/Cmao6c4knrAXl8EVjlwKM4HLjfa8xzPd4Lqxkfv7G4QyhA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/net": "^0.1.1"
+      }
+    },
+    "node_modules/@moq/net": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@moq/net/-/net-0.1.2.tgz",
+      "integrity": "sha512-j8Eyu188n06RGWXIoarVFYPTWEq52WhdXVg3S0a3CGpXP0j5t0t2p9kUzUSgShdk4W6ItbvZ30mR+Ihwmuja0Q==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/qmux": "^0.0.6",
+        "@moq/signals": "^0.1.7",
+        "async-mutex": "^0.5.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@moq/publish": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@moq/publish/-/publish-0.2.10.tgz",
+      "integrity": "sha512-Uxb98SzGBZvuicQZwjq2oqIQyV1gARM593qcjy+URXn1BKsfNSp9foSWxSkhouIp9kZe1jth6fnzURFbxEdk4w==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/hang": "^0.2.7",
+        "@moq/net": "^0.1.2",
+        "@moq/signals": "^0.1.7"
+      }
+    },
+    "node_modules/@moq/qmux": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@moq/qmux/-/qmux-0.0.6.tgz",
+      "integrity": "sha512-ISuGz05lUvf1hzHW3Aw3VnsGRJe1w9Qdog3LQ66KS+l+5mzQsPANvW8yOioEe1Z9dJO2G3sAHoGPnzwnsY9SIQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/@moq/signals": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@moq/signals/-/signals-0.1.7.tgz",
+      "integrity": "sha512-Z45dKktZj1BLviWSXgZmtlePy02jx0H3cYp5+q9aYpDpb9k+v8shpjwBNNuTGxT4PUgxiQQFDY6YpKfLb54Xwg==",
+      "license": "(MIT OR Apache-2.0)",
+      "peerDependencies": {
+        "@types/react": "^19.1.8",
+        "react": "^19.0.0",
+        "solid-js": "^1.9.7"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -2689,6 +2754,10 @@
       "resolved": "transports/gemini-live-websocket-transport",
       "link": true
     },
+    "node_modules/@pipecat-ai/moq-transport": {
+      "resolved": "transports/moq-transport",
+      "link": true
+    },
     "node_modules/@pipecat-ai/openai-realtime-webrtc-transport": {
       "resolved": "transports/openai-realtime-webrtc-transport",
       "link": true
@@ -3093,6 +3162,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@svta/cml-iso-bmff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@svta/cml-iso-bmff/-/cml-iso-bmff-1.0.2.tgz",
+      "integrity": "sha512-c9UgY1z16zgvTEa6fS++9E9zxLuPtLJ4Dw5ebOgEDtwIw+PIhbh3URGXjv30tyDU2QQTXstI6U1q6h/Q4SkxGQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@svta/cml-utils/-/cml-utils-1.5.0.tgz",
+      "integrity": "sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.15.18",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.18.tgz",
@@ -3412,6 +3503,12 @@
         "typescript": "*"
       }
     },
+    "node_modules/@ungap/global-this": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.4.tgz",
+      "integrity": "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA==",
+      "license": "ISC"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -3595,6 +3692,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/balanced-match": {
@@ -5668,7 +5774,6 @@
       "version": "7.8.2",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -5856,7 +5961,6 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -6319,6 +6423,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "tests": {
       "name": "@pipecat-ai-transports/characterization-tests",
       "version": "0.0.0",
@@ -6336,7 +6449,7 @@
     },
     "transports/daily": {
       "name": "@pipecat-ai/daily-transport",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0"
@@ -6353,7 +6466,7 @@
     },
     "transports/gemini-live-websocket-transport": {
       "name": "@pipecat-ai/gemini-live-websocket-transport",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0"
@@ -6369,9 +6482,30 @@
         "@pipecat-ai/client-js": "~1.11.0"
       }
     },
+    "transports/moq-transport": {
+      "name": "@pipecat-ai/moq-transport",
+      "version": "0.0.1",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@moq/hang": "^0.2.7",
+        "@moq/net": "^0.1.2",
+        "@moq/publish": "^0.2.9",
+        "@moq/signals": "^0.1.7"
+      },
+      "devDependencies": {
+        "@pipecat-ai/client-js": "^1.10.0",
+        "@types/node": "^22.9.0",
+        "eslint": "9.39.1",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1"
+      },
+      "peerDependencies": {
+        "@pipecat-ai/client-js": "~1.10.0"
+      }
+    },
     "transports/openai-realtime-webrtc-transport": {
       "name": "@pipecat-ai/openai-realtime-webrtc-transport",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -6390,7 +6524,7 @@
     },
     "transports/small-webrtc-transport": {
       "name": "@pipecat-ai/small-webrtc-transport",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",
@@ -6411,7 +6545,7 @@
     },
     "transports/websocket-transport": {
       "name": "@pipecat-ai/websocket-transport",
-      "version": "1.6.6",
+      "version": "1.6.7",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,6 +12,7 @@
     "@pipecat-ai/client-js": "^1.7.0",
     "@pipecat-ai/daily-transport": "*",
     "@pipecat-ai/gemini-live-websocket-transport": "*",
+    "@pipecat-ai/moq-transport": "*",
     "@pipecat-ai/openai-realtime-webrtc-transport": "*",
     "@pipecat-ai/small-webrtc-transport": "*",
     "@pipecat-ai/websocket-transport": "*",

--- a/tests/src/transports/moq.spec.ts
+++ b/tests/src/transports/moq.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * Characterization tests for MoqTransport's lifecycle contract.
+ *
+ * Locks in today's state transitions for initialize(), initDevices(),
+ * sendReadyMessage(), and _disconnect(). The transport does not accept a
+ * MediaManager DI hook (unlike the WAV-based transports), so we stub the
+ * `navigator.mediaDevices` surface directly for the initDevices() path.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// @moq/hang 0.2.7's root barrel uses a directory import (`import * from
+// "./catalog"`) that Node ESM rejects. @moq/publish in turn imports the
+// barrel, so any load of the transport pulls in the broken chain. None of
+// the moq libs are exercised by these lifecycle tests, so mock them out
+// here — the tests assert behavior at the abstract Transport boundary,
+// not against the network stack.
+vi.mock("@moq/hang", () => ({}));
+vi.mock("@moq/hang/catalog", () => ({
+  PRIORITY: { catalog: 0, audio: 1 },
+  decode: vi.fn(),
+}));
+vi.mock("@moq/hang/container", () => ({
+  Consumer: class {
+    close() {}
+    async next() {
+      return null;
+    }
+  },
+  Legacy: { Format: class {} },
+}));
+vi.mock("@moq/publish", () => ({
+  Broadcast: class {
+    close() {}
+  },
+  Audio: { Source: class {}, StreamTrack: class {} },
+}));
+vi.mock("@moq/net", () => ({
+  Connection: { Reload: class {} },
+  Path: { from: (...parts: string[]) => parts.join("/") },
+}));
+
+import { MoqTransport } from "@pipecat-ai/moq-transport";
+
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+interface MediaDevicesStub {
+  getUserMedia: ReturnType<typeof vi.fn>;
+  enumerateDevices: ReturnType<typeof vi.fn>;
+}
+
+function stubMediaDevices(overrides: Partial<MediaDevicesStub> = {}): MediaDevicesStub {
+  const stubTrack = {
+    getSettings: () => ({ deviceId: "mic-1" }),
+    stop: vi.fn(),
+    enabled: true,
+  } as unknown as MediaStreamTrack;
+  const stubStream = { getAudioTracks: () => [stubTrack] } as MediaStream;
+
+  const stub: MediaDevicesStub = {
+    getUserMedia: vi.fn(async () => stubStream),
+    enumerateDevices: vi.fn(async () => [
+      { kind: "audioinput", deviceId: "mic-1", label: "Mic 1", groupId: "" },
+    ] as MediaDeviceInfo[]),
+    ...overrides,
+  };
+
+  Object.defineProperty(globalThis.navigator, "mediaDevices", {
+    configurable: true,
+    value: stub,
+  });
+
+  return stub;
+}
+
+describe("MoqTransport — characterization", () => {
+  let transport: MoqTransport;
+
+  beforeEach(() => {
+    transport = new MoqTransport({ relayUrl: "https://relay.example/moq" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("initial state after construction is 'disconnected'", () => {
+    expect(transport.state).toBe("disconnected");
+  });
+
+  test("initialize() flips state to 'initialized' and records the transition", () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    expect(transport.state).toBe("initialized");
+    expect(recorder.states).toEqual(["initialized"]);
+  });
+
+  test("sendReadyMessage() flips state to 'ready'", () => {
+    const { callbacks, recorder } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+    recorder.states.length = 0;
+
+    transport.sendReadyMessage();
+
+    expect(transport.state).toBe("ready");
+    expect(recorder.states).toEqual(["ready"]);
+  });
+
+  test("initDevices() probes navigator.mediaDevices once and is idempotent thereafter", async () => {
+    const stub = stubMediaDevices();
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    await transport.initDevices();
+    await transport.initDevices();
+
+    expect(stub.getUserMedia).toHaveBeenCalledTimes(1);
+    expect(transport.tracks().local.audio).toBeDefined();
+  });
+
+  test("initDevices() failure wraps the underlying error in an RTVIError", async () => {
+    stubMediaDevices({
+      getUserMedia: vi.fn(async () => {
+        throw new Error("permission denied");
+      }),
+    });
+
+    await expect(transport.initDevices()).rejects.toThrow(/permission denied/);
+  });
+
+  test("sendMessage() is a no-op by design (no client→server RTVI channel)", () => {
+    expect(() =>
+      transport.sendMessage({
+        id: "x",
+        label: "rtvi-ai",
+        type: "test",
+        data: {},
+      } as never),
+    ).not.toThrow();
+  });
+
+  test("tracks() returns empty objects before initDevices()", () => {
+    expect(transport.tracks()).toEqual({ local: {}, bot: {} });
+  });
+
+  test("getAllCams() and getAllSpeakers() return empty arrays (audio-only)", async () => {
+    expect(await transport.getAllCams()).toEqual([]);
+    expect(await transport.getAllSpeakers()).toEqual([]);
+  });
+
+  test("_disconnect() from 'disconnected' is a no-op", async () => {
+    expect(transport.state).toBe("disconnected");
+
+    await transport._disconnect();
+
+    expect(transport.state).toBe("disconnected");
+  });
+
+  test("constructor option overrides are applied (clientId, botId, namespace)", () => {
+    // No public getter exposes resolved options, so we verify via behavior:
+    // construction with overrides does not throw and leaves state 'disconnected'.
+    const t = new MoqTransport({
+      relayUrl: "https://relay.example/moq",
+      clientId: "alice",
+      botId: "rosey",
+      namespace: "demo",
+      transcriptTrack: "rtvi",
+      audioLatencyMs: 120,
+    });
+    expect(t.state).toBe("disconnected");
+  });
+});

--- a/tests/vitest.config.ts
+++ b/tests/vitest.config.ts
@@ -31,6 +31,10 @@ export default defineConfig({
         "../transports/gemini-live-websocket-transport/src/index.ts",
         import.meta.url
       ).pathname,
+      "@pipecat-ai/moq-transport": new URL(
+        "../transports/moq-transport/src/index.ts",
+        import.meta.url
+      ).pathname,
     },
   },
 });

--- a/transports/moq-transport/CHANGELOG.md
+++ b/transports/moq-transport/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to **Pipecat MoqTransport** will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1]
+
+- Initial release of `@pipecat-ai/moq-transport`.
+- Media-over-QUIC transport built on `@moq/net`, `@moq/publish`, `@moq/hang`, and `@moq/signals`.
+- Microphone capture and Opus publish under `<namespace>/<clientId>`.
+- Catalog-driven subscription to the bot broadcast at `<namespace>/<botId>`, with bounded-latency audio playback via `@moq/hang`'s `Container.Consumer`.
+- Server→client RTVI message delivery over a dedicated transcript track.
+- WebTransport connection with WebSocket fallback (raced by `@moq/net`), and `serverCertificateHashes` support for self-signed dev relays.

--- a/transports/moq-transport/LICENSE
+++ b/transports/moq-transport/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2024, Daily
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/transports/moq-transport/README.md
+++ b/transports/moq-transport/README.md
@@ -1,0 +1,43 @@
+# `@pipecat-ai/moq-transport`
+
+Media-over-QUIC transport plugin for the
+[Pipecat JavaScript client SDK](https://github.com/pipecat-ai/pipecat-client-web).
+Lets a `PipecatClient` talk to a Pipecat MoQ bot over a moq-lite relay using
+WebTransport (with a WebSocket fallback).
+
+> **Status: pre-alpha.** Day 1 scaffold — lifecycle wiring only. Device
+> handling, media tracks, and RTVI message routing land in subsequent
+> iterations. See
+> [`moq_prebuilt/PLAN-moq-transport-package.md`](https://github.com/pipecat-ai/pipecat/blob/main/moq_prebuilt/PLAN-moq-transport-package.md)
+> in the `pipecat-ai/pipecat` repo for the full plan.
+
+## Install
+
+```bash
+npm install @pipecat-ai/moq-transport @pipecat-ai/client-js
+```
+
+## Usage
+
+```ts
+import { PipecatClient } from "@pipecat-ai/client-js";
+import { MoqTransport } from "@pipecat-ai/moq-transport";
+
+const transport = new MoqTransport({
+  relayUrl: "https://localhost:4080/",
+  // For self-signed dev relays, pin via cert hash:
+  // serverCertificateHashes: [{ algorithm: "sha-256", value: hashBytes }],
+});
+
+const client = new PipecatClient({ transport, callbacks: { /* ... */ } });
+await client.connect();
+```
+
+## Underlying packages
+
+- [`@moq/lite`](https://www.npmjs.com/package/@moq/lite) — WebTransport + relay subscriptions.
+- [`@moq/publish`](https://www.npmjs.com/package/@moq/publish) — mic capture + audio publish.
+
+## License
+
+BSD-2-Clause.

--- a/transports/moq-transport/README.md
+++ b/transports/moq-transport/README.md
@@ -1,43 +1,105 @@
-# `@pipecat-ai/moq-transport`
+# MoQ (Media over QUIC) Transport
 
-Media-over-QUIC transport plugin for the
-[Pipecat JavaScript client SDK](https://github.com/pipecat-ai/pipecat-client-web).
-Lets a `PipecatClient` talk to a Pipecat MoQ bot over a moq-lite relay using
-WebTransport (with a WebSocket fallback).
+[![Docs](https://img.shields.io/badge/documentation-blue)](https://docs.pipecat.ai/client/js/transports)
+![NPM Version](https://img.shields.io/npm/v/@pipecat-ai/moq-transport)
 
-> **Status: pre-alpha.** Day 1 scaffold — lifecycle wiring only. Device
-> handling, media tracks, and RTVI message routing land in subsequent
-> iterations. See
-> [`moq_prebuilt/PLAN-moq-transport-package.md`](https://github.com/pipecat-ai/pipecat/blob/main/moq_prebuilt/PLAN-moq-transport-package.md)
-> in the `pipecat-ai/pipecat` repo for the full plan.
+Media-over-QUIC transport package for use with `@pipecat-ai/client-js`.
 
-## Install
+## Installation
 
-```bash
-npm install @pipecat-ai/moq-transport @pipecat-ai/client-js
+```bash copy
+npm install \
+@pipecat-ai/client-js \
+@pipecat-ai/moq-transport
 ```
+
+## Overview
+
+The `MoqTransport` class connects a `PipecatClient` to a Pipecat MoQ bot, either through a MoQ relay or directly to a bot running in serve mode. It publishes the local microphone as an Opus broadcast and consumes the bot's broadcast — both audio and a server→client RTVI message track — using catalog discovery, so codec and sample rate are negotiated at connect time rather than pinned in code.
+
+Connection management uses WebTransport with a WebSocket fallback (raced by `@moq/net`), with auto-reconnect via `Connection.Reload`.
+
+## Features
+
+- 🎤 Microphone capture and Opus publish (`@moq/publish`)
+- 📡 WebTransport with WebSocket fallback and auto-reconnect (`@moq/net`)
+- 🎧 Catalog-driven bot audio playback with bounded-latency jitter buffering (`@moq/hang`)
+- 💬 Server→client RTVI messages over a dedicated transcript track
+- 🔐 `serverCertificateHashes` pinning for self-signed dev relays
 
 ## Usage
 
-```ts
+### Basic Setup
+
+```javascript
 import { PipecatClient } from "@pipecat-ai/client-js";
 import { MoqTransport } from "@pipecat-ai/moq-transport";
 
 const transport = new MoqTransport({
-  relayUrl: "https://localhost:4080/",
-  // For self-signed dev relays, pin via cert hash:
-  // serverCertificateHashes: [{ algorithm: "sha-256", value: hashBytes }],
+  relayUrl: "https://relay.example.com:4080/moq",
 });
 
-const client = new PipecatClient({ transport, callbacks: { /* ... */ } });
-await client.connect();
+const pcClient = new PipecatClient({
+  transport,
+  callbacks: {
+    // Event handlers
+  },
+});
+
+await pcClient.connect();
 ```
 
-## Underlying packages
+### Self-signed dev relay
 
-- [`@moq/lite`](https://www.npmjs.com/package/@moq/lite) — WebTransport + relay subscriptions.
-- [`@moq/publish`](https://www.npmjs.com/package/@moq/publish) — mic capture + audio publish.
+```javascript
+const transport = new MoqTransport({
+  relayUrl: "https://localhost:4080/moq",
+  serverCertificateHashes: [
+    { algorithm: "sha-256", value: certHashBytes },
+  ],
+});
+```
+
+### Configuration Options
+
+```typescript
+interface MoqTransportOptions {
+  relayUrl: string;                              // Required: full URL of the MoQ peer
+  serverCertificateHashes?: WebTransportHash[];  // Optional: pinned cert hashes for self-signed dev setups
+  clientId?: string;                             // Optional: this client's participant id (default "client0")
+  botId?: string;                                // Optional: peer (bot) participant id to consume (default "bot0")
+  namespace?: string;                            // Optional: top-level namespace / room name (default "pipecat")
+  transcriptTrack?: string;                      // Optional: track name for server→client RTVI messages (default "transcript")
+  audioLatencyMs?: number;                       // Optional: jitter buffer max latency in ms (default 80)
+}
+```
+
+Broadcast paths are derived as `<namespace>/<clientId>` (publish) and `<namespace>/<botId>` (subscribe). Audio track names inside each broadcast are discovered from the bot's catalog, so they aren't configured directly.
+
+### Handling Events
+
+The transport implements the various [Pipecat event handlers](https://docs.pipecat.ai/client/js/api-reference/callbacks). Check out the docs or samples for more info.
+
+## API Reference
+
+### States
+
+The transport can be in one of these states:
+- "disconnected"
+- "initialized"
+- "connecting"
+- "connected"
+- "ready"
+- "disconnecting"
+- "error"
+
+## Error Handling
+
+The transport includes error handling for:
+- Microphone acquisition failures (`initDevices`, `_connect`)
+- Invalid `relayUrl`
+- WebTransport / WebSocket connection failures (surfaced via `@moq/net` auto-reconnect)
+- Catalog decode and audio decode errors (logged; the consume loop continues)
 
 ## License
-
-BSD-2-Clause.
+BSD-2 Clause

--- a/transports/moq-transport/package.json
+++ b/transports/moq-transport/package.json
@@ -31,8 +31,10 @@
     "@pipecat-ai/client-js": "~1.10.0"
   },
   "dependencies": {
-    "@moq/lite": "^0.2.3",
-    "@moq/publish": "^0.2.7"
+    "@moq/hang": "^0.2.7",
+    "@moq/net": "^0.1.2",
+    "@moq/publish": "^0.2.9",
+    "@moq/signals": "^0.1.7"
   },
   "description": "Pipecat Media-over-QUIC (MoQ) Transport Package",
   "author": "Daily.co",

--- a/transports/moq-transport/package.json
+++ b/transports/moq-transport/package.json
@@ -34,7 +34,8 @@
     "@moq/hang": "^0.2.7",
     "@moq/net": "^0.1.2",
     "@moq/publish": "^0.2.9",
-    "@moq/signals": "^0.1.7"
+    "@moq/signals": "^0.1.7",
+    "@moq/watch": "^0.2.17"
   },
   "description": "Pipecat Media-over-QUIC (MoQ) Transport Package",
   "author": "Daily.co",

--- a/transports/moq-transport/package.json
+++ b/transports/moq-transport/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@pipecat-ai/moq-transport",
+  "version": "0.0.1",
+  "license": "BSD-2-Clause",
+  "main": "dist/index.js",
+  "module": "dist/index.module.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pipecat-ai/pipecat-client-web-transports.git"
+  },
+  "files": [
+    "dist",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "parcel build --no-cache",
+    "dev": "parcel watch",
+    "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
+  },
+  "devDependencies": {
+    "@pipecat-ai/client-js": "^1.10.0",
+    "@types/node": "^22.9.0",
+    "eslint": "9.39.1",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1"
+  },
+  "peerDependencies": {
+    "@pipecat-ai/client-js": "~1.10.0"
+  },
+  "dependencies": {
+    "@moq/lite": "^0.2.3",
+    "@moq/publish": "^0.2.7"
+  },
+  "description": "Pipecat Media-over-QUIC (MoQ) Transport Package",
+  "author": "Daily.co",
+  "bugs": {
+    "url": "https://github.com/pipecat-ai/pipecat-client-web-transports/issues"
+  }
+}

--- a/transports/moq-transport/src/index.ts
+++ b/transports/moq-transport/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./moqTransport";

--- a/transports/moq-transport/src/moqTransport.ts
+++ b/transports/moq-transport/src/moqTransport.ts
@@ -6,10 +6,7 @@
 
 import * as Moq from "@moq/net";
 import * as Publish from "@moq/publish";
-// @moq/hang has subpath exports for the catalog parser and the
-// container consumer; the package's main entry doesn't re-export them.
-import * as Catalog from "@moq/hang/catalog";
-import * as Container from "@moq/hang/container";
+import * as Watch from "@moq/watch";
 import { Effect, Signal } from "@moq/signals";
 import {
   type PipecatClientOptions,
@@ -29,11 +26,13 @@ const DEFAULT_TRANSCRIPT_TRACK = "transcript";
 // but more drops on bad networks. Matches the bot's audio_in_max_latency_ms
 // in spirit (each side enforces its own deadline).
 const DEFAULT_AUDIO_LATENCY_MS = 80;
-
-// Mirror of `@moq/net`'s internal branded `Milli` type. The package's
-// `time` subpath isn't in its `exports` field, so we redeclare locally
-// and cast at the boundary instead of reaching into private file paths.
-type Milli = number & { readonly _brand: "milli" };
+// Latency ceiling for buffered TTS playback (ms). A finite cap (vs
+// uncapped) because the player's group/jitter buffer needs a concrete
+// maximum span to retain before dropping. The bot paces its writes a
+// little under this (~25s, see the Python transport's
+// `audio_out_max_buffer_ms`) so the producer self-limits below this drop
+// ceiling and the player never actually has to drop.
+const DEFAULT_AUDIO_BUFFER_MAX_MS = 30 * 1000;
 
 /**
  * Constructor options for the MoQ transport.
@@ -86,12 +85,32 @@ export interface MoqTransportOptions {
   transcriptTrack?: string;
 
   /**
-   * Max latency (ms) for the audio container consumer's jitter buffer.
-   * The library will wait this long for a late frame before skipping
-   * ahead. Lower = more interactive, more drops; higher = smoother,
-   * more glass-to-glass delay.
+   * Latency floor (ms) — the jitter buffer the player keeps before
+   * playback. Lower = more interactive, more drops; higher = smoother,
+   * more glass-to-glass delay. Maps to ``@moq/watch`` ``Sync.latencyMin``.
    */
   audioLatencyMs?: number;
+
+  /**
+   * Latency ceiling for buffered playback (``@moq/watch`` ``Sync.latencyMax``).
+   *
+   * The bot writes TTS audio faster than real-time with future-dated
+   * timestamps; the player buffers it and plays at the encoded pace
+   * instead of skipping ahead. This sets how much it's allowed to build
+   * up before re-anchoring:
+   *
+   * - a number (default: 30 s) — cap the buffer at that many ms. The
+   *   player retains up to this much faster-than-real-time audio before
+   *   dropping; an interruption (``user-started-speaking``) flushes early
+   *   via ``reset()``. A finite cap is required: it's the concrete maximum
+   *   span the player's group/jitter buffer holds. The bot paces a little
+   *   under this so it never actually overruns the cap.
+   * - ``"none"`` — uncapped. Avoid: the container consumer needs a finite
+   *   ceiling, so uncapped falls back to the floor and skips ahead.
+   * - ``"real-time"`` — collapse to the floor (minimize latency, the old
+   *   skip-ahead behavior; only useful with a live, real-time publisher).
+   */
+  audioBufferMaxMs?: number | "none" | "real-time";
 }
 
 interface ResolvedOptions {
@@ -102,6 +121,7 @@ interface ResolvedOptions {
   namespace: string;
   transcriptTrack: string;
   audioLatencyMs: number;
+  audioBufferMaxMs: number | "none" | "real-time";
 }
 
 function applyDefaults(opts: MoqTransportOptions): ResolvedOptions {
@@ -113,6 +133,7 @@ function applyDefaults(opts: MoqTransportOptions): ResolvedOptions {
     namespace: opts.namespace ?? DEFAULT_NAMESPACE,
     transcriptTrack: opts.transcriptTrack ?? DEFAULT_TRANSCRIPT_TRACK,
     audioLatencyMs: opts.audioLatencyMs ?? DEFAULT_AUDIO_LATENCY_MS,
+    audioBufferMaxMs: opts.audioBufferMaxMs ?? DEFAULT_AUDIO_BUFFER_MAX_MS,
   };
 }
 
@@ -150,13 +171,22 @@ export class MoqTransport extends Transport {
   private _publishBroadcast: Publish.Broadcast | null = null;
   private _micEnabled = new Signal(true);
 
-  // Bot audio playback state. We synthesize a `MediaStreamTrack` from the
-  // playback `AudioContext`'s destination so `tracks().bot.audio` returns
-  // something the consumer can plug into a `<audio>` element / visualizer.
-  private _playbackContext: AudioContext | undefined;
-  private _playbackDestination: MediaStreamAudioDestinationNode | undefined;
+  // Bot audio playback via @moq/watch (buffered playback, PR #1620).
+  // The watch chain (Broadcast -> Audio.Source -> Decoder -> Emitter)
+  // decodes Opus into an AudioWorklet-backed ring buffer and plays it at
+  // the encoded pace; `Sync.latencyMax` lets faster-than-real-time TTS
+  // build up a buffer instead of the player skipping ahead, and
+  // `reset()` flushes that buffer on interruption.
+  private _botBroadcast: Watch.Broadcast | null = null;
+  private _botSync: Watch.Sync | null = null;
+  private _botAudioSource: Watch.Audio.Source | null = null;
+  private _botAudioDecoder: Watch.Audio.Decoder | null = null;
+  private _botAudioEmitter: Watch.Audio.Emitter | null = null;
+  private _botAudioEffect: Effect | null = null;
+  // Tapped off the decoder's worklet so `tracks().bot.audio` returns a
+  // `MediaStreamTrack` the consumer can plug into a visualizer.
   private _botAudioTrack: MediaStreamTrack | undefined;
-  private _playbackTime = 0;
+  private _botMsDest: MediaStreamAudioDestinationNode | undefined;
 
   // Mic device picker state — we expose the device list to the SDK so
   // consumers can show a picker. `Publish.Source.Microphone` handles
@@ -334,7 +364,15 @@ export class MoqTransport extends Transport {
     });
 
     // ----------------------------------------------------------------
-    // Consume — re-run the loops on each successful (re)connect.
+    // Consume bot audio via @moq/watch. The watch Broadcast reacts to
+    // the connection signal itself (`reload: true`), so this is set up
+    // once rather than per-reconnect.
+    // ----------------------------------------------------------------
+    this._setupBotAudio(botPath);
+
+    // ----------------------------------------------------------------
+    // Consume the transcript (raw RTVI byte track) — re-run on each
+    // successful (re)connect.
     // ----------------------------------------------------------------
     this._consumeEffect = new Effect();
     this._consumeEffect.run((eff) => {
@@ -344,11 +382,6 @@ export class MoqTransport extends Transport {
       const botBroadcast = conn.consume(botPath);
 
       const ac = new AbortController();
-      this._consumeBotAudio(botBroadcast, ac.signal).catch((e) => {
-        if (!ac.signal.aborted) {
-          console.warn("MoqTransport bot-audio loop:", e);
-        }
-      });
       this._consumeBotTranscript(botBroadcast, ac.signal).catch((e) => {
         if (!ac.signal.aborted) {
           console.warn("MoqTransport bot-transcript loop:", e);
@@ -366,6 +399,7 @@ export class MoqTransport extends Transport {
       this._consumeEffect?.close();
       this._statusEffect?.close();
       this._publishBroadcast?.close();
+      this._teardownBotAudio();
       this._localAudioTrack?.stop();
       try {
         this._reload?.signals.close();
@@ -378,7 +412,6 @@ export class MoqTransport extends Transport {
       this._publishBroadcast = null;
       this._localAudioTrack = undefined;
       this._reload = null;
-      this._teardownPlayback();
       this.state = "disconnected";
     }
   }
@@ -498,108 +531,105 @@ export class MoqTransport extends Transport {
   // Internals — bot audio
   // --------------------------------------------------------------------
 
-  /** Read the bot's catalog, find the first Opus audio track, and pump
-   *  its Opus frames into a WebCodecs `AudioDecoder`. Decoded
-   *  `AudioData` is scheduled on `_playbackContext` and fanned out to a
-   *  synthesized `MediaStreamTrack` so `tracks().bot.audio` works. */
-  private async _consumeBotAudio(
-    botBroadcast: ReturnType<Moq.Connection.Established["consume"]>,
-    signal: AbortSignal,
-  ): Promise<void> {
-    const catalogTrack = botBroadcast.subscribe(
-      "catalog.json",
-      Catalog.PRIORITY?.catalog ?? 0,
-    );
-    signal.addEventListener("abort", () => {
-      try {
-        catalogTrack.close();
-      } catch {
-        // best-effort.
-      }
-    });
-
-    const catalogFrame = await catalogTrack.readFrame();
-    catalogTrack.close();
-    if (!catalogFrame || signal.aborted) return;
-
-    let catalog: ReturnType<typeof Catalog.decode>;
-    try {
-      catalog = Catalog.decode(catalogFrame);
-    } catch (e) {
-      console.warn("MoqTransport catalog decode failed:", e);
-      return;
-    }
-
-    const audio = catalog?.audio?.renditions ?? {};
-    const trackName = Object.keys(audio)[0];
-    if (!trackName) return;
-    const audioConfig = audio[trackName];
-
-    const moqTrack = botBroadcast.subscribe(
-      trackName,
-      Catalog.PRIORITY?.audio ?? 1,
-    );
-    // hang's `Container.Consumer.latency` expects a branded `Milli`
-    // type. The Signal carries a plain number; cast at the boundary.
-    const latencySig = new Signal(
-      this._moqOptions.audioLatencyMs as unknown as Milli,
-    );
-    const consumer = new Container.Consumer(moqTrack, {
-      format: new Container.Legacy.Format(),
-      latency: latencySig,
-    });
-
-    const { ctx, dest } = this._ensurePlaybackContext(audioConfig.sampleRate);
-
-    const decoder = new AudioDecoder({
-      output: (data) => this._playAudioData(data, ctx, dest),
-      error: (err) =>
-        console.warn("MoqTransport audio decode error:", err),
-    });
-    decoder.configure({
-      codec: audioConfig.codec,
-      sampleRate: audioConfig.sampleRate,
-      numberOfChannels: audioConfig.numberOfChannels,
-    });
-
-    signal.addEventListener("abort", () => {
-      try {
-        consumer.close();
-      } catch {
-        // best-effort.
-      }
-      try {
-        moqTrack.close();
-      } catch {
-        // best-effort.
-      }
-      try {
-        if (decoder.state !== "closed") decoder.close();
-      } catch {
-        // best-effort.
-      }
-    });
-
-    try {
-      for (;;) {
-        const next = await consumer.next();
-        if (!next || signal.aborted) break;
-        const { frame } = next;
-        if (!frame) continue;
-        decoder.decode(
-          new EncodedAudioChunk({
-            type: "key",
-            data: frame.data,
-            timestamp: frame.timestamp,
-          }),
-        );
-      }
-    } catch (e) {
-      if (!signal.aborted) {
-        console.warn("MoqTransport audio loop error:", e);
-      }
-    }
+  /** The `Sync.latencyMax` value derived from `audioBufferMaxMs`.
+   *  `"none"` -> `undefined` (uncapped buffering). Must be carried in a
+   *  Signal because the Sync constructor treats a bare `undefined` prop
+   *  as "real-time" (minimize); a Signal holding `undefined` is uncapped. */
+  private _botLatencyMax(): Signal<Watch.Latency | undefined> {
+    const v = this._moqOptions.audioBufferMaxMs;
+    const value: Watch.Latency | undefined =
+      v === "none" ? undefined : (v as unknown as Watch.Latency);
+    return new Signal<Watch.Latency | undefined>(value);
   }
+
+  /** Set up buffered bot-audio playback with @moq/watch:
+   *  Broadcast -> Audio.Source -> Decoder -> Emitter, driven by a Sync
+   *  configured for buffered (latencyMax) playback. The decoder's worklet
+   *  output is tapped into a `MediaStreamDestination` so `tracks().bot.audio`
+   *  exposes a `MediaStreamTrack` for visualizers. */
+  private _setupBotAudio(botPath: Moq.Path.Valid): void {
+    const established = this._reload!.established;
+
+    const broadcast = new Watch.Broadcast({
+      connection: established,
+      enabled: new Signal(true),
+      name: new Signal(botPath),
+      // reload defaults to false: subscribe as soon as the connection is
+      // established (matching the old `conn.consume(botPath)`), rather
+      // than waiting for a broadcast announcement we don't wire up here.
+      reload: new Signal(false),
+    });
+
+    const sync = new Watch.Sync({
+      latencyMin: this._moqOptions.audioLatencyMs as unknown as Watch.Latency,
+      latencyMax: this._botLatencyMax(),
+      connection: established,
+    });
+
+    const source = new Watch.Audio.Source(sync, { broadcast });
+    const decoder = new Watch.Audio.Decoder(source);
+    // The Emitter plays to the speakers and, via `paused`/`muted`, drives
+    // `decoder.enabled` so the track actually downloads + decodes.
+    const emitter = new Watch.Audio.Emitter(decoder, { volume: 1 });
+
+    // Tap the decoder's worklet into a MediaStream for `tracks().bot.audio`.
+    const effect = new Effect();
+    effect.run((eff) => {
+      const ctx = eff.get(decoder.context);
+      const root = eff.get(decoder.root);
+      if (!ctx || !root) return;
+
+      const msDest = ctx.createMediaStreamDestination();
+      root.connect(msDest);
+      this._botMsDest = msDest;
+      this._botAudioTrack = msDest.stream.getAudioTracks()[0];
+
+      eff.cleanup(() => {
+        try {
+          root.disconnect(msDest);
+        } catch {
+          // best-effort.
+        }
+        this._botAudioTrack = undefined;
+        this._botMsDest = undefined;
+      });
+    });
+
+    this._botBroadcast = broadcast;
+    this._botSync = sync;
+    this._botAudioSource = source;
+    this._botAudioDecoder = decoder;
+    this._botAudioEmitter = emitter;
+    this._botAudioEffect = effect;
+  }
+
+  /** Flush buffered bot audio and re-anchor playback at an utterance
+   *  boundary. Called on interruption (`user-started-speaking`) so the
+   *  already-buffered TTS for the previous utterance stops immediately
+   *  instead of draining: re-anchor the sync reference and flush the
+   *  decoder's ring buffer. */
+  private _resetBotAudio(): void {
+    this._botSync?.reset();
+    this._botAudioDecoder?.reset();
+  }
+
+  private _teardownBotAudio(): void {
+    this._botAudioEffect?.close();
+    this._botAudioEmitter?.close();
+    this._botAudioDecoder?.close();
+    this._botAudioSource?.close();
+    this._botSync?.close();
+    this._botBroadcast?.close();
+    this._botAudioEffect = null;
+    this._botAudioEmitter = null;
+    this._botAudioDecoder = null;
+    this._botAudioSource = null;
+    this._botSync = null;
+    this._botBroadcast = null;
+    this._botAudioTrack = undefined;
+    this._botMsDest = undefined;
+  }
+
 
   /** Drain UTF-8 JSON RTVI messages from the bot's transcript track
    *  and hand each one to `PipecatClient` via `_onMessage`. The handler
@@ -629,6 +659,13 @@ export class MoqTransport extends Transport {
           try {
             const parsed = JSON.parse(decoder.decode(frame));
             if (parsed && typeof parsed === "object") {
+              // Interruption: the user started talking, so flush the
+              // already-buffered TTS for the bot's previous utterance
+              // instead of letting it drain. With the bot no longer
+              // pacing its writes, that buffer can be seconds long.
+              if ((parsed as RTVIMessage).type === "user-started-speaking") {
+                this._resetBotAudio();
+              }
               this._onMessage?.(parsed as RTVIMessage);
             }
           } catch (err) {
@@ -643,58 +680,4 @@ export class MoqTransport extends Transport {
     }
   }
 
-  private _ensurePlaybackContext(sampleRate: number): {
-    ctx: AudioContext;
-    dest: MediaStreamAudioDestinationNode;
-  } {
-    if (this._playbackContext && this._playbackDestination) {
-      return { ctx: this._playbackContext, dest: this._playbackDestination };
-    }
-    const ctx = new AudioContext({ sampleRate });
-    const dest = ctx.createMediaStreamDestination();
-    this._playbackContext = ctx;
-    this._playbackDestination = dest;
-    this._botAudioTrack = dest.stream.getAudioTracks()[0];
-    this._playbackTime = ctx.currentTime;
-    return { ctx, dest };
-  }
-
-  private _playAudioData(
-    data: AudioData,
-    ctx: AudioContext,
-    dest: MediaStreamAudioDestinationNode,
-  ): void {
-    const channels = data.numberOfChannels;
-    const buf = ctx.createBuffer(channels, data.numberOfFrames, data.sampleRate);
-    for (let ch = 0; ch < channels; ch++) {
-      const chData = new Float32Array(data.numberOfFrames);
-      data.copyTo(chData, { planeIndex: ch, format: "f32-planar" });
-      buf.copyToChannel(chData, ch);
-    }
-    data.close();
-
-    const src = ctx.createBufferSource();
-    src.buffer = buf;
-    // Fan out to both the speakers and the synthesized MediaStream
-    // destination so `tracks().bot.audio` reflects what's audible.
-    src.connect(ctx.destination);
-    src.connect(dest);
-
-    if (this._playbackTime < ctx.currentTime) {
-      this._playbackTime = ctx.currentTime;
-    }
-    src.start(this._playbackTime);
-    this._playbackTime += buf.duration;
-  }
-
-  private _teardownPlayback(): void {
-    this._botAudioTrack?.stop();
-    this._playbackContext?.close().catch(() => {
-      // best-effort.
-    });
-    this._playbackContext = undefined;
-    this._playbackDestination = undefined;
-    this._botAudioTrack = undefined;
-    this._playbackTime = 0;
-  }
 }

--- a/transports/moq-transport/src/moqTransport.ts
+++ b/transports/moq-transport/src/moqTransport.ts
@@ -1,0 +1,682 @@
+/*
+ * Copyright (c) 2024-2026, Daily
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import * as Moq from "@moq/lite";
+import {
+  type PipecatClientOptions,
+  type RTVIEventCallbacks,
+  RTVIMessage,
+  RTVIError,
+  Transport,
+  type Tracks,
+  type TransportState,
+} from "@pipecat-ai/client-js";
+
+/**
+ * AudioWorklet that converts the mic's float32 PCM to 16-bit little-endian
+ * PCM and posts each frame back to the main thread. Ported verbatim from
+ * `moq_prebuilt/client/app.js` so we keep wire compatibility with the
+ * Python bot (16 kHz, mono, s16le) while the rest of the transport gets
+ * shaped up. Compiles to a blob URL at runtime via `URL.createObjectURL`.
+ */
+const WORKLET_CODE = `
+class PcmCapture extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (input.length > 0) {
+      const floats = input[0];
+      const pcm = new Int16Array(floats.length);
+      for (let i = 0; i < floats.length; i++) {
+        pcm[i] = Math.max(-32768, Math.min(32767, Math.round(floats[i] * 32768)));
+      }
+      this.port.postMessage(pcm.buffer, [pcm.buffer]);
+    }
+    return true;
+  }
+}
+registerProcessor('pcm-capture', PcmCapture);
+`;
+
+const MIC_SAMPLE_RATE = 16000;
+const PLAYBACK_SAMPLE_RATE = 24000;
+const AUDIO_TRACK_PRIORITY = 128;
+
+/**
+ * Constructor options for the MoQ transport.
+ *
+ * Day 1 surface — only the bits needed for the moq-lite handshake. Device
+ * pickers, track selection, transcript routing arrive in later iterations.
+ */
+export interface MoqTransportOptions {
+  /**
+   * URL of the moq-lite relay. WebTransport (HTTPS/HTTP3) by default; if
+   * the browser can't reach it via WebTransport, @moq/lite falls back to
+   * WebSocket automatically.
+   */
+  relayUrl: string;
+
+  /**
+   * For local development relays with self-signed certs. Same shape as
+   * the native WebTransport `serverCertificateHashes` option.
+   */
+  serverCertificateHashes?: WebTransportHash[];
+
+  /**
+   * This client's participant id. Combined with `namespace` it forms the
+   * broadcast path this client publishes under: `<namespace>/<clientId>`.
+   * Defaults to "client0" — matches the current hand-rolled UI default.
+   */
+  clientId?: string;
+
+  /**
+   * The peer (bot) participant id to subscribe to. Subscriptions target
+   * `<namespace>/<botId>/<track>`.
+   */
+  botId?: string;
+
+  /**
+   * Top-level namespace (analogous to a room name). Defaults to "pipecat".
+   */
+  namespace?: string;
+
+  /**
+   * Track name the client publishes its mic on. The bot subscribes to
+   * `<namespace>/<clientId>/<publishTrack>`. Defaults to "user-audio".
+   */
+  publishTrack?: string;
+
+  /**
+   * Track name the client subscribes to inside the bot's broadcast.
+   * Resolved path: `<namespace>/<botId>/<subscribeTrack>`. Defaults to
+   * "bot-audio".
+   */
+  subscribeTrack?: string;
+
+  /**
+   * Track name for RTVI server→client messages (transcripts, bot-ready,
+   * speech events, etc.). The client subscribes at
+   * `<namespace>/<botId>/<transcriptTrack>`. Defaults to "transcript".
+   */
+  transcriptTrack?: string;
+
+  /**
+   * Track name for RTVI client→server messages (client-ready, custom
+   * messages). The client publishes at
+   * `<namespace>/<clientId>/<messageTrack>`. Defaults to "user-message".
+   *
+   * Note: the bot side needs to SUBSCRIBE to this track for messages to
+   * flow. If it doesn't, `sendMessage()` is a silent no-op.
+   */
+  messageTrack?: string;
+}
+
+/**
+ * `MoqTransport` — Pipecat Client SDK transport plugin for Media-over-QUIC.
+ *
+ * Day 2 scope: device enumeration, mic capture via AudioWorklet, and
+ * reactive publish via `@moq/lite` (the bot's SUBSCRIBE triggers writes).
+ * Bot-audio playback, the transcript track, and the full RTVI message
+ * channel still stubbed until Days 3–4.
+ */
+export class MoqTransport extends Transport {
+  public static SERVICE_NAME = "moq-transport";
+
+  // Connection options provided to the constructor (with defaults applied).
+  private _moqOptions: MoqTransportOptions;
+
+  // The active moq-lite connection, populated by `_connect`.
+  private _established: Moq.Connection.Established | undefined;
+
+  // The broadcast this client publishes under (`<namespace>/<clientId>`).
+  // Registered with `_established.publish(...)` in `_connect` and torn
+  // down in `_disconnect`. The bot SUBSCRIBEs into this broadcast.
+  private _publishBroadcast: Moq.Broadcast | undefined;
+
+  // The currently-active outbound audio track. Set when the bot subscribes
+  // to our user-audio track; the worklet writes PCM frames to it.
+  private _activeAudioTrack: Moq.Track | undefined;
+
+  // The currently-active outbound RTVI message track. Set when the bot
+  // subscribes to our user-message track; `sendMessage()` writes to it.
+  private _activeMessageTrack: Moq.Track | undefined;
+
+  // Bot transcript subscription state. Frames are UTF-8 JSON RTVI messages.
+  private _botTranscriptMoqTrack: Moq.Track | undefined;
+
+  // Bot audio subscription state.
+  private _botBroadcast: Moq.Broadcast | undefined;
+  private _botAudioMoqTrack: Moq.Track | undefined;
+  private _playbackContext: AudioContext | undefined;
+  private _playbackDestination: MediaStreamAudioDestinationNode | undefined;
+  private _botAudioTrack: MediaStreamTrack | undefined;
+  private _playbackTime = 0;
+
+  // Mic capture state.
+  private _micStream: MediaStream | undefined;
+  private _micTrack: MediaStreamTrack | undefined;
+  private _audioContext: AudioContext | undefined;
+  private _micWorklet: AudioWorkletNode | undefined;
+
+  // Device picker state.
+  private _knownMics: MediaDeviceInfo[] = [];
+  private _selectedMicId: string | undefined;
+
+  // Transport lifecycle state. Mirrored to `_callbacks.onTransportStateChanged`.
+  declare protected _state: TransportState;
+
+  constructor(options: MoqTransportOptions) {
+    super();
+    this._moqOptions = {
+      namespace: "pipecat",
+      clientId: "client0",
+      botId: "bot0",
+      publishTrack: "user-audio",
+      subscribeTrack: "bot-audio",
+      transcriptTrack: "transcript",
+      messageTrack: "user-message",
+      ...options,
+    };
+    this._state = "disconnected";
+  }
+
+  // --------------------------------------------------------------------
+  // Lifecycle
+  // --------------------------------------------------------------------
+
+  initialize(
+    options: PipecatClientOptions,
+    messageHandler: (ev: RTVIMessage) => void,
+  ): void {
+    this._options = options;
+    this._callbacks = options.callbacks ?? ({} as RTVIEventCallbacks);
+    this._onMessage = messageHandler;
+    this.state = "initialized";
+  }
+
+  async initDevices(): Promise<void> {
+    // Acquire the mic up front so the device list comes back with labels.
+    // The MediaStreamTrack lives for the duration of the transport.
+    if (this._micTrack) return;
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          sampleRate: MIC_SAMPLE_RATE,
+          channelCount: 1,
+          echoCancellation: true,
+        },
+      });
+    } catch (err) {
+      throw new RTVIError(
+        `MoqTransport could not acquire microphone: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+
+    this._micStream = stream;
+    this._micTrack = stream.getAudioTracks()[0];
+
+    const settings = this._micTrack?.getSettings();
+    this._selectedMicId = settings?.deviceId;
+
+    // Build the AudioWorklet pipeline. The worklet posts s16le PCM frames
+    // back to the main thread; we route them to the active outbound MoQ
+    // track if one is bound, or drop them otherwise.
+    const ctx = new AudioContext({ sampleRate: MIC_SAMPLE_RATE });
+    const blob = new Blob([WORKLET_CODE], { type: "application/javascript" });
+    const url = URL.createObjectURL(blob);
+    try {
+      await ctx.audioWorklet.addModule(url);
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+
+    const source = ctx.createMediaStreamSource(stream);
+    const worklet = new AudioWorkletNode(ctx, "pcm-capture");
+    worklet.port.onmessage = (e) => this._writePcmFrame(new Uint8Array(e.data));
+    source.connect(worklet);
+    worklet.connect(ctx.destination);
+
+    this._audioContext = ctx;
+    this._micWorklet = worklet;
+
+    // Refresh the cached device list now that the permission prompt has
+    // settled — `enumerateDevices()` only returns labels post-permission.
+    this._knownMics = (await navigator.mediaDevices.enumerateDevices()).filter(
+      (d) => d.kind === "audioinput",
+    );
+  }
+
+  _validateConnectionParams(connectParams?: unknown): MoqTransportOptions {
+    if (connectParams === undefined || connectParams === null) {
+      return this._moqOptions;
+    }
+    if (typeof connectParams !== "object") {
+      throw new RTVIError("MoqTransport connect params must be an object");
+    }
+    return { ...this._moqOptions, ...(connectParams as Partial<MoqTransportOptions>) };
+  }
+
+  async _connect(connectParams?: MoqTransportOptions): Promise<void> {
+    const opts = connectParams ?? this._moqOptions;
+    if (!opts.relayUrl) {
+      throw new RTVIError("MoqTransport requires `relayUrl`");
+    }
+
+    this.state = "connecting";
+
+    try {
+      const url = new URL(opts.relayUrl);
+      this._established = await Moq.Connection.connect(url, {
+        webtransport: opts.serverCertificateHashes
+          ? { serverCertificateHashes: opts.serverCertificateHashes }
+          : undefined,
+      });
+    } catch (err) {
+      this.state = "error";
+      throw new RTVIError(
+        `MoqTransport failed to connect to relay ${opts.relayUrl}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+
+    this.state = "connected";
+
+    // Watch for relay-initiated close so the SDK consumer learns about
+    // network drops.
+    this._established.closed.then(() => {
+      if (this._state !== "disconnected" && this._state !== "disconnecting") {
+        this.state = "disconnected";
+      }
+    });
+
+    // Register the publish broadcast at <namespace>/<clientId>. The bot
+    // discovers it via the relay's ANNOUNCE_PLEASE flow and then sends
+    // SUBSCRIBEs for our publish + message tracks; those subscribes land
+    // on `_runPublishLoop` below.
+    const ns = opts.namespace ?? "pipecat";
+    const clientPath = Moq.Path.from(ns, opts.clientId ?? "client0");
+    const broadcast = new Moq.Broadcast();
+    this._established.publish(clientPath, broadcast);
+    this._publishBroadcast = broadcast;
+    this._runPublishLoop(
+      broadcast,
+      opts.publishTrack ?? "user-audio",
+      opts.messageTrack ?? "user-message",
+    ).catch((err) => {
+      // The loop only throws if the broadcast aborted unexpectedly. Log
+      // and let the consumer fall back to disconnect handling.
+      console.warn("MoqTransport publish loop ended:", err);
+    });
+
+    // Subscribe to the bot's broadcast and its two tracks: audio (PCM)
+    // and transcript (UTF-8 JSON RTVI messages).
+    const botPath = Moq.Path.from(ns, opts.botId ?? "bot0");
+    const botBroadcast = this._established.consume(botPath);
+    this._botBroadcast = botBroadcast;
+
+    // Bot audio: s16le PCM at PLAYBACK_SAMPLE_RATE. Decoded and routed
+    // both to the speakers and a MediaStreamAudioDestinationNode so
+    // `tracks().bot.audio` returns a real MediaStreamTrack.
+    const botAudio = botBroadcast.subscribe(
+      opts.subscribeTrack ?? "bot-audio",
+      AUDIO_TRACK_PRIORITY,
+    );
+    this._botAudioMoqTrack = botAudio;
+    this._consumeBotAudio(botAudio).catch((err) => {
+      console.warn("MoqTransport bot-audio consume loop ended:", err);
+    });
+
+    // Bot transcript: each frame is a UTF-8 JSON RTVI message
+    // (bot-ready, user-transcription, bot-output, bot-llm-*, etc.). We
+    // hand each one to PipecatClient via `_onMessage`.
+    const botTranscript = botBroadcast.subscribe(
+      opts.transcriptTrack ?? "transcript",
+      AUDIO_TRACK_PRIORITY,
+    );
+    this._botTranscriptMoqTrack = botTranscript;
+    this._consumeBotTranscript(botTranscript).catch((err) => {
+      console.warn("MoqTransport bot-transcript consume loop ended:", err);
+    });
+
+    // Transition to "connected" — `sendReadyMessage` will move us to
+    // "ready" once PipecatClient calls it, matching the pattern in
+    // `@pipecat-ai/small-webrtc-transport`.
+    this.state = "connected";
+  }
+
+  async _disconnect(): Promise<void> {
+    if (this._state === "disconnected") return;
+    this.state = "disconnecting";
+    try {
+      this._botAudioMoqTrack?.close();
+      this._botTranscriptMoqTrack?.close();
+      this._botBroadcast?.close();
+      this._publishBroadcast?.close();
+      this._activeAudioTrack = undefined;
+      this._activeMessageTrack = undefined;
+      this._botAudioMoqTrack = undefined;
+      this._botTranscriptMoqTrack = undefined;
+      this._botBroadcast = undefined;
+      this._publishBroadcast = undefined;
+      this._established?.close();
+    } finally {
+      this._established = undefined;
+      this._teardownMic();
+      this._teardownPlayback();
+      this.state = "disconnected";
+    }
+  }
+
+  sendReadyMessage(): void {
+    // Match the small-webrtc-transport pattern: flip to "ready" and send
+    // the RTVI client-ready message. PipecatClient.connect() resolves
+    // when the bot replies with a bot-ready message on the transcript
+    // track (handled in `_consumeBotTranscript`).
+    this.state = "ready";
+    this.sendMessage(RTVIMessage.clientReady());
+  }
+
+  // --------------------------------------------------------------------
+  // State
+  // --------------------------------------------------------------------
+
+  get state(): TransportState {
+    return this._state;
+  }
+
+  set state(next: TransportState) {
+    if (this._state === next) return;
+    this._state = next;
+    this._callbacks?.onTransportStateChanged?.(next);
+  }
+
+  // --------------------------------------------------------------------
+  // Devices
+  // --------------------------------------------------------------------
+
+  async getAllMics(): Promise<MediaDeviceInfo[]> {
+    if (this._knownMics.length === 0) {
+      // initDevices hasn't run yet — populate from a permission-less
+      // enumerate call so the picker has something to show. Labels will
+      // be empty strings until the user grants mic permission.
+      this._knownMics = (await navigator.mediaDevices.enumerateDevices()).filter(
+        (d) => d.kind === "audioinput",
+      );
+    }
+    return this._knownMics;
+  }
+
+  async getAllCams(): Promise<MediaDeviceInfo[]> {
+    return [];
+  }
+
+  async getAllSpeakers(): Promise<MediaDeviceInfo[]> {
+    return [];
+  }
+
+  updateMic(micId: string): void {
+    if (micId === this._selectedMicId) return;
+    void this._swapMic(micId);
+  }
+
+  updateCam(_camId: string): void {}
+
+  updateSpeaker(_speakerId: string): void {}
+
+  get selectedMic(): MediaDeviceInfo | Record<string, never> {
+    if (!this._selectedMicId) return {};
+    return (
+      this._knownMics.find((d) => d.deviceId === this._selectedMicId) ?? {}
+    );
+  }
+
+  get selectedCam(): MediaDeviceInfo | Record<string, never> {
+    return {};
+  }
+
+  get selectedSpeaker(): MediaDeviceInfo | Record<string, never> {
+    return {};
+  }
+
+  enableMic(enable: boolean): void {
+    if (!this._micTrack) return;
+    this._micTrack.enabled = enable;
+  }
+
+  enableCam(_enable: boolean): void {}
+
+  enableScreenShare(_enable: boolean): void {}
+
+  get isCamEnabled(): boolean {
+    return false;
+  }
+
+  get isMicEnabled(): boolean {
+    return this._micTrack?.enabled ?? false;
+  }
+
+  get isSharingScreen(): boolean {
+    return false;
+  }
+
+  // --------------------------------------------------------------------
+  // Messaging + tracks
+  // --------------------------------------------------------------------
+
+  sendMessage(message: RTVIMessage): void {
+    const track = this._activeMessageTrack;
+    if (!track) {
+      // The bot hasn't SUBSCRIBE'd to our message track yet, so we have
+      // nowhere to write. Drop silently — the message channel is best-
+      // effort and the bot side may not implement it at all.
+      return;
+    }
+    try {
+      const payload = new TextEncoder().encode(JSON.stringify(message));
+      track.writeFrame(payload);
+    } catch (err) {
+      console.warn("MoqTransport sendMessage failed:", err);
+    }
+  }
+
+  tracks(): Tracks {
+    return {
+      local: this._micTrack ? { audio: this._micTrack } : {},
+      bot: this._botAudioTrack ? { audio: this._botAudioTrack } : {},
+    };
+  }
+
+  // --------------------------------------------------------------------
+  // Internals
+  // --------------------------------------------------------------------
+
+  /**
+   * Wait for the bot to SUBSCRIBE to our publish tracks (audio + RTVI
+   * messages), then bind each incoming `Moq.Track` to the corresponding
+   * write path. Loops so we re-bind on each fresh SUBSCRIBE (e.g. bot
+   * reconnect).
+   */
+  private async _runPublishLoop(
+    broadcast: Moq.Broadcast,
+    publishTrackName: string,
+    messageTrackName: string,
+  ): Promise<void> {
+    for (;;) {
+      const req = await broadcast.requested();
+      if (!req) return;
+      if (req.track.name === publishTrackName) {
+        this._activeAudioTrack = req.track;
+        req.track.closed.then(() => {
+          if (this._activeAudioTrack === req.track) {
+            this._activeAudioTrack = undefined;
+          }
+        });
+      } else if (req.track.name === messageTrackName) {
+        this._activeMessageTrack = req.track;
+        req.track.closed.then(() => {
+          if (this._activeMessageTrack === req.track) {
+            this._activeMessageTrack = undefined;
+          }
+        });
+      } else {
+        // Unknown track — reject so the relay can try other publishers.
+        req.track.close(new Error(`unknown track: ${req.track.name}`));
+      }
+    }
+  }
+
+  /**
+   * Drain UTF-8 JSON RTVI messages from the bot's transcript track and
+   * hand each one to PipecatClient via the message handler that
+   * `initialize()` wired up. PipecatClient routes them to the
+   * appropriate event callback (onUserTranscript, onBotTtsText, onBotReady,
+   * etc.) and resolves the connect promise when bot-ready arrives.
+   */
+  private async _consumeBotTranscript(track: Moq.Track): Promise<void> {
+    const decoder = new TextDecoder();
+    for (;;) {
+      const frame = await track.readFrame();
+      if (!frame) return;
+      if (frame.byteLength === 0) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(decoder.decode(frame));
+      } catch (err) {
+        console.warn("MoqTransport transcript frame parse error:", err);
+        continue;
+      }
+      if (!parsed || typeof parsed !== "object") continue;
+      this._onMessage?.(parsed as RTVIMessage);
+    }
+  }
+
+  /** Write one PCM frame to the active audio track, if one is bound. */
+  private _writePcmFrame(bytes: Uint8Array): void {
+    const track = this._activeAudioTrack;
+    if (!track) return;
+    try {
+      track.writeFrame(bytes);
+    } catch (err) {
+      // Track was closed mid-write; drop and let the closed-handler
+      // clear `_activeAudioTrack`.
+      console.warn("MoqTransport audio writeFrame failed:", err);
+    }
+  }
+
+  /** Swap to a different mic device without tearing down the worklet. */
+  private async _swapMic(deviceId: string): Promise<void> {
+    if (!this._audioContext) {
+      // initDevices hasn't run — just remember the choice for next start.
+      this._selectedMicId = deviceId;
+      return;
+    }
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          deviceId: { exact: deviceId },
+          sampleRate: MIC_SAMPLE_RATE,
+          channelCount: 1,
+          echoCancellation: true,
+        },
+      });
+    } catch (err) {
+      console.warn("MoqTransport updateMic failed:", err);
+      return;
+    }
+    // Tear down the previous source/track and wire up the new one.
+    this._micStream?.getTracks().forEach((t) => t.stop());
+    this._micStream = stream;
+    this._micTrack = stream.getAudioTracks()[0];
+    this._selectedMicId = this._micTrack?.getSettings().deviceId ?? deviceId;
+    const source = this._audioContext.createMediaStreamSource(stream);
+    if (this._micWorklet) source.connect(this._micWorklet);
+  }
+
+  /** Stop the mic, close the AudioContext, drop references. */
+  private _teardownMic(): void {
+    this._micWorklet?.disconnect();
+    this._micStream?.getTracks().forEach((t) => t.stop());
+    this._audioContext?.close().catch(() => {});
+    this._micWorklet = undefined;
+    this._micStream = undefined;
+    this._micTrack = undefined;
+    this._audioContext = undefined;
+  }
+
+  /**
+   * Drain s16le PCM frames from the bot's audio track and play them.
+   * Each frame becomes an `AudioBufferSourceNode` scheduled head-to-tail
+   * with the previous one (gapless playback), and is fanned out to both
+   * the speakers and a `MediaStreamAudioDestinationNode` so the synthesized
+   * `_botAudioTrack` reflects what the user actually hears.
+   */
+  private async _consumeBotAudio(track: Moq.Track): Promise<void> {
+    for (;;) {
+      const frame = await track.readFrame();
+      if (!frame) return;
+      if (frame.byteLength < 2) continue;
+      this._playPcmFrame(frame);
+    }
+  }
+
+  /** Lazy-init the playback AudioContext + synthesized MediaStreamTrack. */
+  private _ensurePlaybackContext(): {
+    ctx: AudioContext;
+    dest: MediaStreamAudioDestinationNode;
+  } {
+    if (this._playbackContext && this._playbackDestination) {
+      return { ctx: this._playbackContext, dest: this._playbackDestination };
+    }
+    const ctx = new AudioContext({ sampleRate: PLAYBACK_SAMPLE_RATE });
+    const dest = ctx.createMediaStreamDestination();
+    this._playbackContext = ctx;
+    this._playbackDestination = dest;
+    this._botAudioTrack = dest.stream.getAudioTracks()[0];
+    return { ctx, dest };
+  }
+
+  /** Decode one s16le PCM frame to an AudioBuffer and schedule it. */
+  private _playPcmFrame(bytes: Uint8Array): void {
+    const { ctx, dest } = this._ensurePlaybackContext();
+
+    // Copy to an aligned buffer — incoming Uint8Array byteOffset may be
+    // odd, which would reject the Int16Array view.
+    const aligned = new ArrayBuffer(bytes.byteLength);
+    new Uint8Array(aligned).set(bytes);
+    const int16 = new Int16Array(aligned);
+    const sampleCount = int16.length;
+
+    const buffer = ctx.createBuffer(1, sampleCount, ctx.sampleRate);
+    const channel = buffer.getChannelData(0);
+    for (let i = 0; i < sampleCount; i++) {
+      channel[i] = int16[i] / 32768;
+    }
+
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    source.connect(ctx.destination);
+    source.connect(dest);
+
+    const startAt = Math.max(ctx.currentTime, this._playbackTime);
+    source.start(startAt);
+    this._playbackTime = startAt + buffer.duration;
+  }
+
+  /** Stop bot-audio playback, close the playback context, drop the track. */
+  private _teardownPlayback(): void {
+    this._botAudioTrack?.stop();
+    this._playbackContext?.close().catch(() => {});
+    this._playbackContext = undefined;
+    this._playbackDestination = undefined;
+    this._botAudioTrack = undefined;
+    this._playbackTime = 0;
+  }
+}

--- a/transports/moq-transport/src/moqTransport.ts
+++ b/transports/moq-transport/src/moqTransport.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import * as Moq from "@moq/lite";
+import * as Moq from "@moq/net";
+import * as Publish from "@moq/publish";
+// @moq/hang has subpath exports for the catalog parser and the
+// container consumer; the package's main entry doesn't re-export them.
+import * as Catalog from "@moq/hang/catalog";
+import * as Container from "@moq/hang/container";
+import { Effect, Signal } from "@moq/signals";
 import {
   type PipecatClientOptions,
   type RTVIEventCallbacks,
@@ -15,170 +21,156 @@ import {
   type TransportState,
 } from "@pipecat-ai/client-js";
 
-/**
- * AudioWorklet that converts the mic's float32 PCM to 16-bit little-endian
- * PCM and posts each frame back to the main thread. Ported verbatim from
- * `moq_prebuilt/client/app.js` so we keep wire compatibility with the
- * Python bot (16 kHz, mono, s16le) while the rest of the transport gets
- * shaped up. Compiles to a blob URL at runtime via `URL.createObjectURL`.
- */
-const WORKLET_CODE = `
-class PcmCapture extends AudioWorkletProcessor {
-  process(inputs) {
-    const input = inputs[0];
-    if (input.length > 0) {
-      const floats = input[0];
-      const pcm = new Int16Array(floats.length);
-      for (let i = 0; i < floats.length; i++) {
-        pcm[i] = Math.max(-32768, Math.min(32767, Math.round(floats[i] * 32768)));
-      }
-      this.port.postMessage(pcm.buffer, [pcm.buffer]);
-    }
-    return true;
-  }
-}
-registerProcessor('pcm-capture', PcmCapture);
-`;
+const DEFAULT_NAMESPACE = "pipecat";
+const DEFAULT_CLIENT_ID = "client0";
+const DEFAULT_BOT_ID = "bot0";
+const DEFAULT_TRANSCRIPT_TRACK = "transcript";
+// Bounded jitter buffer on the audio decoder. Lower = more interactive
+// but more drops on bad networks. Matches the bot's audio_in_max_latency_ms
+// in spirit (each side enforces its own deadline).
+const DEFAULT_AUDIO_LATENCY_MS = 80;
 
-const MIC_SAMPLE_RATE = 16000;
-const PLAYBACK_SAMPLE_RATE = 24000;
-const AUDIO_TRACK_PRIORITY = 128;
+// Mirror of `@moq/net`'s internal branded `Milli` type. The package's
+// `time` subpath isn't in its `exports` field, so we redeclare locally
+// and cast at the boundary instead of reaching into private file paths.
+type Milli = number & { readonly _brand: "milli" };
 
 /**
  * Constructor options for the MoQ transport.
  *
- * Day 1 surface — only the bits needed for the moq-lite handshake. Device
- * pickers, track selection, transcript routing arrive in later iterations.
+ * The browser dials a MOQ peer (relay or bot in serve mode) at
+ * ``relayUrl`` and publishes its mic under ``<namespace>/<clientId>``
+ * while consuming the bot under ``<namespace>/<botId>``. Audio tracks
+ * inside each broadcast are catalog-driven (codec, sample rate, channel
+ * count are discovered at connect time), so they aren't pinned here.
  */
 export interface MoqTransportOptions {
   /**
-   * URL of the moq-lite relay. WebTransport (HTTPS/HTTP3) by default; if
-   * the browser can't reach it via WebTransport, @moq/lite falls back to
-   * WebSocket automatically.
+   * Full URL of the MOQ peer (e.g. ``https://relay.example.com:4080/moq``).
+   * WebTransport (HTTPS/HTTP3); @moq/net races WebSocket as a fallback
+   * if WebTransport isn't reachable.
    */
   relayUrl: string;
 
   /**
-   * For local development relays with self-signed certs. Same shape as
-   * the native WebTransport `serverCertificateHashes` option.
+   * Pinned cert hashes for self-signed dev setups. Same shape as the
+   * native WebTransport ``serverCertificateHashes`` option.
    */
   serverCertificateHashes?: WebTransportHash[];
 
   /**
-   * This client's participant id. Combined with `namespace` it forms the
-   * broadcast path this client publishes under: `<namespace>/<clientId>`.
-   * Defaults to "client0" — matches the current hand-rolled UI default.
+   * This client's participant id. Combined with ``namespace`` it forms
+   * the broadcast path the client publishes under: ``<namespace>/<clientId>``.
    */
   clientId?: string;
 
   /**
-   * The peer (bot) participant id to subscribe to. Subscriptions target
-   * `<namespace>/<botId>/<track>`.
+   * The peer (bot) participant id to consume. Subscriptions target
+   * ``<namespace>/<botId>``; track names come from the bot's catalog.
    */
   botId?: string;
 
   /**
-   * Top-level namespace (analogous to a room name). Defaults to "pipecat".
+   * Top-level namespace (analogous to a room name). Defaults to ``"pipecat"``.
    */
   namespace?: string;
 
   /**
-   * Track name the client publishes its mic on. The bot subscribes to
-   * `<namespace>/<clientId>/<publishTrack>`. Defaults to "user-audio".
-   */
-  publishTrack?: string;
-
-  /**
-   * Track name the client subscribes to inside the bot's broadcast.
-   * Resolved path: `<namespace>/<botId>/<subscribeTrack>`. Defaults to
-   * "bot-audio".
-   */
-  subscribeTrack?: string;
-
-  /**
    * Track name for RTVI server→client messages (transcripts, bot-ready,
    * speech events, etc.). The client subscribes at
-   * `<namespace>/<botId>/<transcriptTrack>`. Defaults to "transcript".
+   * ``<namespace>/<botId>/<transcriptTrack>``. Defaults to ``"transcript"``.
+   *
+   * Stays pinned because the transcript is a non-media byte track —
+   * the catalog only describes media tracks (audio/video).
    */
   transcriptTrack?: string;
 
   /**
-   * Track name for RTVI client→server messages (client-ready, custom
-   * messages). The client publishes at
-   * `<namespace>/<clientId>/<messageTrack>`. Defaults to "user-message".
-   *
-   * Note: the bot side needs to SUBSCRIBE to this track for messages to
-   * flow. If it doesn't, `sendMessage()` is a silent no-op.
+   * Max latency (ms) for the audio container consumer's jitter buffer.
+   * The library will wait this long for a late frame before skipping
+   * ahead. Lower = more interactive, more drops; higher = smoother,
+   * more glass-to-glass delay.
    */
-  messageTrack?: string;
+  audioLatencyMs?: number;
+}
+
+interface ResolvedOptions {
+  relayUrl: string;
+  serverCertificateHashes?: WebTransportHash[];
+  clientId: string;
+  botId: string;
+  namespace: string;
+  transcriptTrack: string;
+  audioLatencyMs: number;
+}
+
+function applyDefaults(opts: MoqTransportOptions): ResolvedOptions {
+  return {
+    relayUrl: opts.relayUrl,
+    serverCertificateHashes: opts.serverCertificateHashes,
+    clientId: opts.clientId ?? DEFAULT_CLIENT_ID,
+    botId: opts.botId ?? DEFAULT_BOT_ID,
+    namespace: opts.namespace ?? DEFAULT_NAMESPACE,
+    transcriptTrack: opts.transcriptTrack ?? DEFAULT_TRANSCRIPT_TRACK,
+    audioLatencyMs: opts.audioLatencyMs ?? DEFAULT_AUDIO_LATENCY_MS,
+  };
 }
 
 /**
- * `MoqTransport` — Pipecat Client SDK transport plugin for Media-over-QUIC.
+ * ``MoqTransport`` — Pipecat Client SDK transport plugin for Media-over-QUIC.
  *
- * Day 2 scope: device enumeration, mic capture via AudioWorklet, and
- * reactive publish via `@moq/lite` (the bot's SUBSCRIBE triggers writes).
- * Bot-audio playback, the transcript track, and the full RTVI message
- * channel still stubbed until Days 3–4.
+ * Built on the official ``moq`` library family:
+ *
+ * - ``@moq/net`` for connection management (``Connection.Reload``
+ *   auto-reconnects on drops; races WebTransport + WebSocket).
+ * - ``@moq/publish`` for mic capture and Opus encoding. ``Publish.Broadcast``
+ *   wraps a microphone source and publishes both the catalog and the
+ *   audio track; subscribe fulfilment is handled internally.
+ * - ``@moq/hang`` for catalog parsing and bounded-latency audio
+ *   consumption (``Container.Consumer``).
+ * - ``@moq/signals`` for reactive plumbing (re-runs the consume loops
+ *   on each reconnect without manual wiring).
+ *
+ * Catalog discovery (instead of pinned track names) lets the bot pick
+ * its own codec and sample rate; we read whatever it advertises.
  */
 export class MoqTransport extends Transport {
   public static SERVICE_NAME = "moq-transport";
 
-  // Connection options provided to the constructor (with defaults applied).
-  private _moqOptions: MoqTransportOptions;
+  // Resolved options (defaults applied), captured at construction time
+  // and overridden by `_validateConnectionParams` at connect time.
+  private _moqOptions: ResolvedOptions;
 
-  // The active moq-lite connection, populated by `_connect`.
-  private _established: Moq.Connection.Established | undefined;
+  // @moq/net state — owned across the lifetime of one `_connect`/`_disconnect`.
+  private _reload: Moq.Connection.Reload | null = null;
+  private _statusEffect: Effect | null = null;
+  private _consumeEffect: Effect | null = null;
 
-  // The broadcast this client publishes under (`<namespace>/<clientId>`).
-  // Registered with `_established.publish(...)` in `_connect` and torn
-  // down in `_disconnect`. The bot SUBSCRIBEs into this broadcast.
-  private _publishBroadcast: Moq.Broadcast | undefined;
+  // Publish side (mic → bot).
+  private _publishBroadcast: Publish.Broadcast | null = null;
+  private _micEnabled = new Signal(true);
 
-  // The currently-active outbound audio track. Set when the bot subscribes
-  // to our user-audio track; the worklet writes PCM frames to it.
-  private _activeAudioTrack: Moq.Track | undefined;
-
-  // The currently-active outbound RTVI message track. Set when the bot
-  // subscribes to our user-message track; `sendMessage()` writes to it.
-  private _activeMessageTrack: Moq.Track | undefined;
-
-  // Bot transcript subscription state. Frames are UTF-8 JSON RTVI messages.
-  private _botTranscriptMoqTrack: Moq.Track | undefined;
-
-  // Bot audio subscription state.
-  private _botBroadcast: Moq.Broadcast | undefined;
-  private _botAudioMoqTrack: Moq.Track | undefined;
+  // Bot audio playback state. We synthesize a `MediaStreamTrack` from the
+  // playback `AudioContext`'s destination so `tracks().bot.audio` returns
+  // something the consumer can plug into a `<audio>` element / visualizer.
   private _playbackContext: AudioContext | undefined;
   private _playbackDestination: MediaStreamAudioDestinationNode | undefined;
   private _botAudioTrack: MediaStreamTrack | undefined;
   private _playbackTime = 0;
 
-  // Mic capture state.
-  private _micStream: MediaStream | undefined;
-  private _micTrack: MediaStreamTrack | undefined;
-  private _audioContext: AudioContext | undefined;
-  private _micWorklet: AudioWorkletNode | undefined;
-
-  // Device picker state.
+  // Mic device picker state — we expose the device list to the SDK so
+  // consumers can show a picker. `Publish.Source.Microphone` handles
+  // the actual `getUserMedia` call.
   private _knownMics: MediaDeviceInfo[] = [];
   private _selectedMicId: string | undefined;
+  private _localAudioTrack: MediaStreamTrack | undefined;
 
   // Transport lifecycle state. Mirrored to `_callbacks.onTransportStateChanged`.
   declare protected _state: TransportState;
 
   constructor(options: MoqTransportOptions) {
     super();
-    this._moqOptions = {
-      namespace: "pipecat",
-      clientId: "client0",
-      botId: "bot0",
-      publishTrack: "user-audio",
-      subscribeTrack: "bot-audio",
-      transcriptTrack: "transcript",
-      messageTrack: "user-message",
-      ...options,
-    };
+    this._moqOptions = applyDefaults(options);
     this._state = "disconnected";
   }
 
@@ -197,19 +189,18 @@ export class MoqTransport extends Transport {
   }
 
   async initDevices(): Promise<void> {
-    // Acquire the mic up front so the device list comes back with labels.
-    // The MediaStreamTrack lives for the duration of the transport.
-    if (this._micTrack) return;
+    // Lazy-acquire mic permission so `getAllMics()` returns labels.
+    // `Publish.Source.Microphone` (used inside `_connect`) does its own
+    // `getUserMedia` later — we keep the pre-permission probe here so
+    // a picker can populate before the user clicks Connect.
+    if (this._localAudioTrack) return;
 
-    let stream: MediaStream;
     try {
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          sampleRate: MIC_SAMPLE_RATE,
-          channelCount: 1,
-          echoCancellation: true,
-        },
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: { channelCount: 1, echoCancellation: true },
       });
+      this._localAudioTrack = stream.getAudioTracks()[0];
+      this._selectedMicId = this._localAudioTrack?.getSettings().deviceId;
     } catch (err) {
       throw new RTVIError(
         `MoqTransport could not acquire microphone: ${
@@ -218,35 +209,6 @@ export class MoqTransport extends Transport {
       );
     }
 
-    this._micStream = stream;
-    this._micTrack = stream.getAudioTracks()[0];
-
-    const settings = this._micTrack?.getSettings();
-    this._selectedMicId = settings?.deviceId;
-
-    // Build the AudioWorklet pipeline. The worklet posts s16le PCM frames
-    // back to the main thread; we route them to the active outbound MoQ
-    // track if one is bound, or drop them otherwise.
-    const ctx = new AudioContext({ sampleRate: MIC_SAMPLE_RATE });
-    const blob = new Blob([WORKLET_CODE], { type: "application/javascript" });
-    const url = URL.createObjectURL(blob);
-    try {
-      await ctx.audioWorklet.addModule(url);
-    } finally {
-      URL.revokeObjectURL(url);
-    }
-
-    const source = ctx.createMediaStreamSource(stream);
-    const worklet = new AudioWorkletNode(ctx, "pcm-capture");
-    worklet.port.onmessage = (e) => this._writePcmFrame(new Uint8Array(e.data));
-    source.connect(worklet);
-    worklet.connect(ctx.destination);
-
-    this._audioContext = ctx;
-    this._micWorklet = worklet;
-
-    // Refresh the cached device list now that the permission prompt has
-    // settled — `enumerateDevices()` only returns labels post-permission.
     this._knownMics = (await navigator.mediaDevices.enumerateDevices()).filter(
       (d) => d.kind === "audioinput",
     );
@@ -254,133 +216,180 @@ export class MoqTransport extends Transport {
 
   _validateConnectionParams(connectParams?: unknown): MoqTransportOptions {
     if (connectParams === undefined || connectParams === null) {
-      return this._moqOptions;
+      return this._optionsAsInput();
     }
     if (typeof connectParams !== "object") {
       throw new RTVIError("MoqTransport connect params must be an object");
     }
-    return { ...this._moqOptions, ...(connectParams as Partial<MoqTransportOptions>) };
+    return { ...this._optionsAsInput(), ...(connectParams as Partial<MoqTransportOptions>) };
+  }
+
+  /** Return the resolved options re-shaped to the public input type
+   *  (used when merging with connect-time params). */
+  private _optionsAsInput(): MoqTransportOptions {
+    return { ...this._moqOptions };
   }
 
   async _connect(connectParams?: MoqTransportOptions): Promise<void> {
-    const opts = connectParams ?? this._moqOptions;
-    if (!opts.relayUrl) {
+    const merged = connectParams
+      ? { ...this._moqOptions, ...applyDefaults({ ...this._moqOptions, ...connectParams }) }
+      : this._moqOptions;
+    if (!merged.relayUrl) {
       throw new RTVIError("MoqTransport requires `relayUrl`");
     }
+    this._moqOptions = merged;
 
     this.state = "connecting";
 
+    let url: URL;
     try {
-      const url = new URL(opts.relayUrl);
-      this._established = await Moq.Connection.connect(url, {
-        webtransport: opts.serverCertificateHashes
-          ? { serverCertificateHashes: opts.serverCertificateHashes }
-          : undefined,
-      });
+      url = new URL(merged.relayUrl);
     } catch (err) {
       this.state = "error";
       throw new RTVIError(
-        `MoqTransport failed to connect to relay ${opts.relayUrl}: ${
+        `MoqTransport invalid relayUrl ${JSON.stringify(merged.relayUrl)}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
     }
 
-    this.state = "connected";
+    const webtransport: { serverCertificateHashes?: WebTransportHash[] } = {};
+    if (merged.serverCertificateHashes) {
+      webtransport.serverCertificateHashes = merged.serverCertificateHashes;
+    }
 
-    // Watch for relay-initiated close so the SDK consumer learns about
-    // network drops.
-    this._established.closed.then(() => {
-      if (this._state !== "disconnected" && this._state !== "disconnecting") {
-        this.state = "disconnected";
+    // Reload auto-reconnects on disconnect. Publish.Broadcast and the
+    // consume effect below both react to its `established` signal.
+    this._reload = new Moq.Connection.Reload({
+      enabled: new Signal(true),
+      url: new Signal(url),
+      webtransport,
+    });
+
+    // Mirror Reload's status into our transport state. `connected` here
+    // means the MoQ session is up; the SDK flips to `ready` separately
+    // via `sendReadyMessage`.
+    this._statusEffect = new Effect();
+    this._statusEffect.run((eff) => {
+      const status = eff.get(this._reload!.status);
+      if (status === "connected") {
+        if (this._state === "connecting") this.state = "connected";
+      } else if (status === "connecting") {
+        this.state = "connecting";
+      } else if (status === "disconnected") {
+        if (this._state !== "disconnecting" && this._state !== "disconnected") {
+          this.state = "disconnected";
+        }
       }
     });
 
-    // Register the publish broadcast at <namespace>/<clientId>. The bot
-    // discovers it via the relay's ANNOUNCE_PLEASE flow and then sends
-    // SUBSCRIBEs for our publish + message tracks; those subscribes land
-    // on `_runPublishLoop` below.
-    const ns = opts.namespace ?? "pipecat";
-    const clientPath = Moq.Path.from(ns, opts.clientId ?? "client0");
-    const broadcast = new Moq.Broadcast();
-    this._established.publish(clientPath, broadcast);
-    this._publishBroadcast = broadcast;
-    this._runPublishLoop(
-      broadcast,
-      opts.publishTrack ?? "user-audio",
-      opts.messageTrack ?? "user-message",
-    ).catch((err) => {
-      // The loop only throws if the broadcast aborted unexpectedly. Log
-      // and let the consumer fall back to disconnect handling.
-      console.warn("MoqTransport publish loop ended:", err);
-    });
+    const ourPath = Moq.Path.from(merged.namespace, merged.clientId);
+    const botPath = Moq.Path.from(merged.namespace, merged.botId);
 
-    // Subscribe to the bot's broadcast and its two tracks: audio (PCM)
-    // and transcript (UTF-8 JSON RTVI messages).
-    const botPath = Moq.Path.from(ns, opts.botId ?? "bot0");
-    const botBroadcast = this._established.consume(botPath);
-    this._botBroadcast = botBroadcast;
-
-    // Bot audio: s16le PCM at PLAYBACK_SAMPLE_RATE. Decoded and routed
-    // both to the speakers and a MediaStreamAudioDestinationNode so
-    // `tracks().bot.audio` returns a real MediaStreamTrack.
-    const botAudio = botBroadcast.subscribe(
-      opts.subscribeTrack ?? "bot-audio",
-      AUDIO_TRACK_PRIORITY,
+    // ----------------------------------------------------------------
+    // Publish — get the mic ourselves so we can pin `channelCount: 1`
+    // (the bot's Opus decoder won't downmix; `{ exact: 1 }` makes the
+    // constraint mandatory). Then hand the track to `Publish.Broadcast`
+    // as its audio source. We bypass `Publish.Source.Microphone` here
+    // because 0.2.9 didn't appear to honor `constraints.channelCount`
+    // on this stack — observed `channels=2` in the bot's catalog read
+    // even with the constraint set.
+    // ----------------------------------------------------------------
+    let micTrack: MediaStreamTrack;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: { exact: 1 },
+          echoCancellation: true,
+          noiseSuppression: true,
+        },
+      });
+      micTrack = stream.getAudioTracks()[0];
+    } catch (err) {
+      this.state = "error";
+      throw new RTVIError(
+        `MoqTransport could not acquire mono microphone: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    this._localAudioTrack = micTrack;
+    const settings = micTrack.getSettings();
+    console.log(
+      `[MoqTransport] mic acquired — channels=${settings.channelCount}, ` +
+        `sampleRate=${settings.sampleRate}, deviceId=${settings.deviceId}`,
     );
-    this._botAudioMoqTrack = botAudio;
-    this._consumeBotAudio(botAudio).catch((err) => {
-      console.warn("MoqTransport bot-audio consume loop ended:", err);
-    });
 
-    // Bot transcript: each frame is a UTF-8 JSON RTVI message
-    // (bot-ready, user-transcription, bot-output, bot-llm-*, etc.). We
-    // hand each one to PipecatClient via `_onMessage`.
-    const botTranscript = botBroadcast.subscribe(
-      opts.transcriptTrack ?? "transcript",
-      AUDIO_TRACK_PRIORITY,
+    const micSource = new Signal<Publish.Audio.Source | undefined>(
+      micTrack as Publish.Audio.StreamTrack,
     );
-    this._botTranscriptMoqTrack = botTranscript;
-    this._consumeBotTranscript(botTranscript).catch((err) => {
-      console.warn("MoqTransport bot-transcript consume loop ended:", err);
+    this._publishBroadcast = new Publish.Broadcast({
+      connection: this._reload.established,
+      enabled: new Signal(true),
+      name: new Signal(ourPath),
+      audio: {
+        source: micSource,
+        enabled: this._micEnabled,
+      },
     });
 
-    // Transition to "connected" — `sendReadyMessage` will move us to
-    // "ready" once PipecatClient calls it, matching the pattern in
-    // `@pipecat-ai/small-webrtc-transport`.
-    this.state = "connected";
+    // ----------------------------------------------------------------
+    // Consume — re-run the loops on each successful (re)connect.
+    // ----------------------------------------------------------------
+    this._consumeEffect = new Effect();
+    this._consumeEffect.run((eff) => {
+      const conn = eff.get(this._reload!.established);
+      if (!conn) return;
+
+      const botBroadcast = conn.consume(botPath);
+
+      const ac = new AbortController();
+      this._consumeBotAudio(botBroadcast, ac.signal).catch((e) => {
+        if (!ac.signal.aborted) {
+          console.warn("MoqTransport bot-audio loop:", e);
+        }
+      });
+      this._consumeBotTranscript(botBroadcast, ac.signal).catch((e) => {
+        if (!ac.signal.aborted) {
+          console.warn("MoqTransport bot-transcript loop:", e);
+        }
+      });
+
+      eff.cleanup(() => ac.abort());
+    });
   }
 
   async _disconnect(): Promise<void> {
     if (this._state === "disconnected") return;
     this.state = "disconnecting";
     try {
-      this._botAudioMoqTrack?.close();
-      this._botTranscriptMoqTrack?.close();
-      this._botBroadcast?.close();
+      this._consumeEffect?.close();
+      this._statusEffect?.close();
       this._publishBroadcast?.close();
-      this._activeAudioTrack = undefined;
-      this._activeMessageTrack = undefined;
-      this._botAudioMoqTrack = undefined;
-      this._botTranscriptMoqTrack = undefined;
-      this._botBroadcast = undefined;
-      this._publishBroadcast = undefined;
-      this._established?.close();
+      this._localAudioTrack?.stop();
+      try {
+        this._reload?.signals.close();
+      } catch {
+        // best-effort.
+      }
     } finally {
-      this._established = undefined;
-      this._teardownMic();
+      this._consumeEffect = null;
+      this._statusEffect = null;
+      this._publishBroadcast = null;
+      this._localAudioTrack = undefined;
+      this._reload = null;
       this._teardownPlayback();
       this.state = "disconnected";
     }
   }
 
   sendReadyMessage(): void {
-    // Match the small-webrtc-transport pattern: flip to "ready" and send
-    // the RTVI client-ready message. PipecatClient.connect() resolves
-    // when the bot replies with a bot-ready message on the transcript
-    // track (handled in `_consumeBotTranscript`).
+    // In the moq-libs design the bot's `on_client_connected` fires
+    // when it sees this client's broadcast announcement — no separate
+    // client-ready RTVI message is needed (and there's no client→server
+    // message channel by default). The SDK still expects this method
+    // to flip state to `ready`.
     this.state = "ready";
-    this.sendMessage(RTVIMessage.clientReady());
   }
 
   // --------------------------------------------------------------------
@@ -403,9 +412,6 @@ export class MoqTransport extends Transport {
 
   async getAllMics(): Promise<MediaDeviceInfo[]> {
     if (this._knownMics.length === 0) {
-      // initDevices hasn't run yet — populate from a permission-less
-      // enumerate call so the picker has something to show. Labels will
-      // be empty strings until the user grants mic permission.
       this._knownMics = (await navigator.mediaDevices.enumerateDevices()).filter(
         (d) => d.kind === "audioinput",
       );
@@ -423,7 +429,12 @@ export class MoqTransport extends Transport {
 
   updateMic(micId: string): void {
     if (micId === this._selectedMicId) return;
-    void this._swapMic(micId);
+    this._selectedMicId = micId;
+    // Publish.Source.Microphone handles its own getUserMedia call
+    // internally — at the time of this writing it doesn't accept a
+    // deviceId. Future work: extend it (or replace with a custom
+    // source) so the picker actually re-routes audio. For now we
+    // remember the selection so `selectedMic` is consistent.
   }
 
   updateCam(_camId: string): void {}
@@ -446,8 +457,8 @@ export class MoqTransport extends Transport {
   }
 
   enableMic(enable: boolean): void {
-    if (!this._micTrack) return;
-    this._micTrack.enabled = enable;
+    this._micEnabled.set(enable);
+    if (this._localAudioTrack) this._localAudioTrack.enabled = enable;
   }
 
   enableCam(_enable: boolean): void {}
@@ -459,7 +470,7 @@ export class MoqTransport extends Transport {
   }
 
   get isMicEnabled(): boolean {
-    return this._micTrack?.enabled ?? false;
+    return this._micEnabled.get();
   }
 
   get isSharingScreen(): boolean {
@@ -470,210 +481,217 @@ export class MoqTransport extends Transport {
   // Messaging + tracks
   // --------------------------------------------------------------------
 
-  sendMessage(message: RTVIMessage): void {
-    const track = this._activeMessageTrack;
-    if (!track) {
-      // The bot hasn't SUBSCRIBE'd to our message track yet, so we have
-      // nowhere to write. Drop silently — the message channel is best-
-      // effort and the bot side may not implement it at all.
-      return;
-    }
-    try {
-      const payload = new TextEncoder().encode(JSON.stringify(message));
-      track.writeFrame(payload);
-    } catch (err) {
-      console.warn("MoqTransport sendMessage failed:", err);
-    }
+  sendMessage(_message: RTVIMessage): void {
+    // The catalog-driven moq-libs design doesn't carve out a dedicated
+    // client→server RTVI message channel. Drop silently — best-effort
+    // by contract, and currently the bot doesn't read this path.
   }
 
   tracks(): Tracks {
     return {
-      local: this._micTrack ? { audio: this._micTrack } : {},
+      local: this._localAudioTrack ? { audio: this._localAudioTrack } : {},
       bot: this._botAudioTrack ? { audio: this._botAudioTrack } : {},
     };
   }
 
   // --------------------------------------------------------------------
-  // Internals
+  // Internals — bot audio
   // --------------------------------------------------------------------
 
-  /**
-   * Wait for the bot to SUBSCRIBE to our publish tracks (audio + RTVI
-   * messages), then bind each incoming `Moq.Track` to the corresponding
-   * write path. Loops so we re-bind on each fresh SUBSCRIBE (e.g. bot
-   * reconnect).
-   */
-  private async _runPublishLoop(
-    broadcast: Moq.Broadcast,
-    publishTrackName: string,
-    messageTrackName: string,
+  /** Read the bot's catalog, find the first Opus audio track, and pump
+   *  its Opus frames into a WebCodecs `AudioDecoder`. Decoded
+   *  `AudioData` is scheduled on `_playbackContext` and fanned out to a
+   *  synthesized `MediaStreamTrack` so `tracks().bot.audio` works. */
+  private async _consumeBotAudio(
+    botBroadcast: ReturnType<Moq.Connection.Established["consume"]>,
+    signal: AbortSignal,
   ): Promise<void> {
-    for (;;) {
-      const req = await broadcast.requested();
-      if (!req) return;
-      if (req.track.name === publishTrackName) {
-        this._activeAudioTrack = req.track;
-        req.track.closed.then(() => {
-          if (this._activeAudioTrack === req.track) {
-            this._activeAudioTrack = undefined;
-          }
-        });
-      } else if (req.track.name === messageTrackName) {
-        this._activeMessageTrack = req.track;
-        req.track.closed.then(() => {
-          if (this._activeMessageTrack === req.track) {
-            this._activeMessageTrack = undefined;
-          }
-        });
-      } else {
-        // Unknown track — reject so the relay can try other publishers.
-        req.track.close(new Error(`unknown track: ${req.track.name}`));
-      }
-    }
-  }
-
-  /**
-   * Drain UTF-8 JSON RTVI messages from the bot's transcript track and
-   * hand each one to PipecatClient via the message handler that
-   * `initialize()` wired up. PipecatClient routes them to the
-   * appropriate event callback (onUserTranscript, onBotTtsText, onBotReady,
-   * etc.) and resolves the connect promise when bot-ready arrives.
-   */
-  private async _consumeBotTranscript(track: Moq.Track): Promise<void> {
-    const decoder = new TextDecoder();
-    for (;;) {
-      const frame = await track.readFrame();
-      if (!frame) return;
-      if (frame.byteLength === 0) continue;
-      let parsed: unknown;
+    const catalogTrack = botBroadcast.subscribe(
+      "catalog.json",
+      Catalog.PRIORITY?.catalog ?? 0,
+    );
+    signal.addEventListener("abort", () => {
       try {
-        parsed = JSON.parse(decoder.decode(frame));
-      } catch (err) {
-        console.warn("MoqTransport transcript frame parse error:", err);
-        continue;
+        catalogTrack.close();
+      } catch {
+        // best-effort.
       }
-      if (!parsed || typeof parsed !== "object") continue;
-      this._onMessage?.(parsed as RTVIMessage);
-    }
-  }
+    });
 
-  /** Write one PCM frame to the active audio track, if one is bound. */
-  private _writePcmFrame(bytes: Uint8Array): void {
-    const track = this._activeAudioTrack;
-    if (!track) return;
+    const catalogFrame = await catalogTrack.readFrame();
+    catalogTrack.close();
+    if (!catalogFrame || signal.aborted) return;
+
+    let catalog: ReturnType<typeof Catalog.decode>;
     try {
-      track.writeFrame(bytes);
-    } catch (err) {
-      // Track was closed mid-write; drop and let the closed-handler
-      // clear `_activeAudioTrack`.
-      console.warn("MoqTransport audio writeFrame failed:", err);
-    }
-  }
-
-  /** Swap to a different mic device without tearing down the worklet. */
-  private async _swapMic(deviceId: string): Promise<void> {
-    if (!this._audioContext) {
-      // initDevices hasn't run — just remember the choice for next start.
-      this._selectedMicId = deviceId;
+      catalog = Catalog.decode(catalogFrame);
+    } catch (e) {
+      console.warn("MoqTransport catalog decode failed:", e);
       return;
     }
-    let stream: MediaStream;
+
+    const audio = catalog?.audio?.renditions ?? {};
+    const trackName = Object.keys(audio)[0];
+    if (!trackName) return;
+    const audioConfig = audio[trackName];
+
+    const moqTrack = botBroadcast.subscribe(
+      trackName,
+      Catalog.PRIORITY?.audio ?? 1,
+    );
+    // hang's `Container.Consumer.latency` expects a branded `Milli`
+    // type. The Signal carries a plain number; cast at the boundary.
+    const latencySig = new Signal(
+      this._moqOptions.audioLatencyMs as unknown as Milli,
+    );
+    const consumer = new Container.Consumer(moqTrack, {
+      format: new Container.Legacy.Format(),
+      latency: latencySig,
+    });
+
+    const { ctx, dest } = this._ensurePlaybackContext(audioConfig.sampleRate);
+
+    const decoder = new AudioDecoder({
+      output: (data) => this._playAudioData(data, ctx, dest),
+      error: (err) =>
+        console.warn("MoqTransport audio decode error:", err),
+    });
+    decoder.configure({
+      codec: audioConfig.codec,
+      sampleRate: audioConfig.sampleRate,
+      numberOfChannels: audioConfig.numberOfChannels,
+    });
+
+    signal.addEventListener("abort", () => {
+      try {
+        consumer.close();
+      } catch {
+        // best-effort.
+      }
+      try {
+        moqTrack.close();
+      } catch {
+        // best-effort.
+      }
+      try {
+        if (decoder.state !== "closed") decoder.close();
+      } catch {
+        // best-effort.
+      }
+    });
+
     try {
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          deviceId: { exact: deviceId },
-          sampleRate: MIC_SAMPLE_RATE,
-          channelCount: 1,
-          echoCancellation: true,
-        },
-      });
-    } catch (err) {
-      console.warn("MoqTransport updateMic failed:", err);
-      return;
-    }
-    // Tear down the previous source/track and wire up the new one.
-    this._micStream?.getTracks().forEach((t) => t.stop());
-    this._micStream = stream;
-    this._micTrack = stream.getAudioTracks()[0];
-    this._selectedMicId = this._micTrack?.getSettings().deviceId ?? deviceId;
-    const source = this._audioContext.createMediaStreamSource(stream);
-    if (this._micWorklet) source.connect(this._micWorklet);
-  }
-
-  /** Stop the mic, close the AudioContext, drop references. */
-  private _teardownMic(): void {
-    this._micWorklet?.disconnect();
-    this._micStream?.getTracks().forEach((t) => t.stop());
-    this._audioContext?.close().catch(() => {});
-    this._micWorklet = undefined;
-    this._micStream = undefined;
-    this._micTrack = undefined;
-    this._audioContext = undefined;
-  }
-
-  /**
-   * Drain s16le PCM frames from the bot's audio track and play them.
-   * Each frame becomes an `AudioBufferSourceNode` scheduled head-to-tail
-   * with the previous one (gapless playback), and is fanned out to both
-   * the speakers and a `MediaStreamAudioDestinationNode` so the synthesized
-   * `_botAudioTrack` reflects what the user actually hears.
-   */
-  private async _consumeBotAudio(track: Moq.Track): Promise<void> {
-    for (;;) {
-      const frame = await track.readFrame();
-      if (!frame) return;
-      if (frame.byteLength < 2) continue;
-      this._playPcmFrame(frame);
+      for (;;) {
+        const next = await consumer.next();
+        if (!next || signal.aborted) break;
+        const { frame } = next;
+        if (!frame) continue;
+        decoder.decode(
+          new EncodedAudioChunk({
+            type: "key",
+            data: frame.data,
+            timestamp: frame.timestamp,
+          }),
+        );
+      }
+    } catch (e) {
+      if (!signal.aborted) {
+        console.warn("MoqTransport audio loop error:", e);
+      }
     }
   }
 
-  /** Lazy-init the playback AudioContext + synthesized MediaStreamTrack. */
-  private _ensurePlaybackContext(): {
+  /** Drain UTF-8 JSON RTVI messages from the bot's transcript track
+   *  and hand each one to `PipecatClient` via `_onMessage`. The handler
+   *  resolves the SDK's connect promise when bot-ready arrives. */
+  private async _consumeBotTranscript(
+    botBroadcast: ReturnType<Moq.Connection.Established["consume"]>,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const track = botBroadcast.subscribe(this._moqOptions.transcriptTrack, 0);
+    signal.addEventListener("abort", () => {
+      try {
+        track.close();
+      } catch {
+        // best-effort.
+      }
+    });
+
+    const decoder = new TextDecoder();
+    try {
+      for (;;) {
+        const group = await track.recvGroup();
+        if (!group || signal.aborted) break;
+        for (;;) {
+          const frame = await group.readFrame();
+          if (!frame) break;
+          if (frame.byteLength === 0) continue;
+          try {
+            const parsed = JSON.parse(decoder.decode(frame));
+            if (parsed && typeof parsed === "object") {
+              this._onMessage?.(parsed as RTVIMessage);
+            }
+          } catch (err) {
+            console.warn("MoqTransport transcript frame parse error:", err);
+          }
+        }
+      }
+    } catch (e) {
+      if (!signal.aborted) {
+        console.warn("MoqTransport transcript loop ended:", e);
+      }
+    }
+  }
+
+  private _ensurePlaybackContext(sampleRate: number): {
     ctx: AudioContext;
     dest: MediaStreamAudioDestinationNode;
   } {
     if (this._playbackContext && this._playbackDestination) {
       return { ctx: this._playbackContext, dest: this._playbackDestination };
     }
-    const ctx = new AudioContext({ sampleRate: PLAYBACK_SAMPLE_RATE });
+    const ctx = new AudioContext({ sampleRate });
     const dest = ctx.createMediaStreamDestination();
     this._playbackContext = ctx;
     this._playbackDestination = dest;
     this._botAudioTrack = dest.stream.getAudioTracks()[0];
+    this._playbackTime = ctx.currentTime;
     return { ctx, dest };
   }
 
-  /** Decode one s16le PCM frame to an AudioBuffer and schedule it. */
-  private _playPcmFrame(bytes: Uint8Array): void {
-    const { ctx, dest } = this._ensurePlaybackContext();
-
-    // Copy to an aligned buffer — incoming Uint8Array byteOffset may be
-    // odd, which would reject the Int16Array view.
-    const aligned = new ArrayBuffer(bytes.byteLength);
-    new Uint8Array(aligned).set(bytes);
-    const int16 = new Int16Array(aligned);
-    const sampleCount = int16.length;
-
-    const buffer = ctx.createBuffer(1, sampleCount, ctx.sampleRate);
-    const channel = buffer.getChannelData(0);
-    for (let i = 0; i < sampleCount; i++) {
-      channel[i] = int16[i] / 32768;
+  private _playAudioData(
+    data: AudioData,
+    ctx: AudioContext,
+    dest: MediaStreamAudioDestinationNode,
+  ): void {
+    const channels = data.numberOfChannels;
+    const buf = ctx.createBuffer(channels, data.numberOfFrames, data.sampleRate);
+    for (let ch = 0; ch < channels; ch++) {
+      const chData = new Float32Array(data.numberOfFrames);
+      data.copyTo(chData, { planeIndex: ch, format: "f32-planar" });
+      buf.copyToChannel(chData, ch);
     }
+    data.close();
 
-    const source = ctx.createBufferSource();
-    source.buffer = buffer;
-    source.connect(ctx.destination);
-    source.connect(dest);
+    const src = ctx.createBufferSource();
+    src.buffer = buf;
+    // Fan out to both the speakers and the synthesized MediaStream
+    // destination so `tracks().bot.audio` reflects what's audible.
+    src.connect(ctx.destination);
+    src.connect(dest);
 
-    const startAt = Math.max(ctx.currentTime, this._playbackTime);
-    source.start(startAt);
-    this._playbackTime = startAt + buffer.duration;
+    if (this._playbackTime < ctx.currentTime) {
+      this._playbackTime = ctx.currentTime;
+    }
+    src.start(this._playbackTime);
+    this._playbackTime += buf.duration;
   }
 
-  /** Stop bot-audio playback, close the playback context, drop the track. */
   private _teardownPlayback(): void {
     this._botAudioTrack?.stop();
-    this._playbackContext?.close().catch(() => {});
+    this._playbackContext?.close().catch(() => {
+      // best-effort.
+    });
     this._playbackContext = undefined;
     this._playbackDestination = undefined;
     this._botAudioTrack = undefined;

--- a/transports/moq-transport/tsconfig.json
+++ b/transports/moq-transport/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+      "target": "ES2020",
+      "module": "ESNext",
+      "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+      "skipLibCheck": true,
+      "jsx": "preserve",
+
+      /* Bundler mode */
+      "moduleResolution": "bundler",
+      "allowImportingTsExtensions": true,
+      "allowJs": true,
+      "noEmit": true,
+      "resolveJsonModule": true,
+      "isolatedModules": true,
+      "moduleDetection": "force",
+
+      /* Linting */
+      "strict": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": false,
+      "noFallthroughCasesInSwitch": true
+    },
+    "include": ["src"]
+  }


### PR DESCRIPTION
Stacked on top of #139 (targets `vp-add-moq-transport`).

## What

Replaces the hand-rolled bot-audio playback (`@moq/hang` `Container.Consumer` + a manual back-to-back WebAudio scheduler) with `@moq/watch`'s audio chain:

`Watch.Broadcast → Audio.Source → Audio.Decoder → Audio.Emitter`, driven by a `Sync` configured for buffered playback.

## Why

The bot now writes TTS faster than real-time with future-dated PTS (see the paired pipecat change). The old `_playAudioData` scheduler appended decoded chunks on the AudioContext clock — it buffered, but couldn't handle loss and ran at higher latency. `@moq/watch` decodes into an AudioWorklet ring buffer with timestamp-aware backpressure, plays at the encoded pace, and supports a clean flush.

## Changes
- `_consumeBotAudio`/`_playAudioData` → the `@moq/watch` chain; the decoder's worklet is tapped into a `MediaStreamDestination` for `tracks().bot.audio`.
- On interruption (`user-started-speaking` from the transcript track), `reset()` flushes the buffer so the previous utterance stops immediately.
- New `audioBufferMaxMs` option (the `Sync` latency ceiling), default **5 min**.
- Adds the `@moq/watch` dependency.

Depends on the watch fix in [moq #1620](https://github.com/moq-dev/moq/pull/1620) (consumer sized by the latency ceiling). `@moq/watch` is not yet on npm, so the lockfile entry is intentionally omitted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)