### PR TITLE
feat(moq): carry the RTVI transcript on a lossless compressed JSON stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -383,7 +383,6 @@
       "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.90.0.tgz",
       "integrity": "sha512-XnuuNIxLt8GOv+rFYoU+OPTSmVj+Mg9hRPK2EM6WYVY62F6rcw7vwzZBOSCisVuu1VnTIF/2J9V0VEBa83lDzw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@sentry/browser": "^8.33.1",
@@ -731,12 +730,12 @@
       }
     },
     "node_modules/@moq/flate": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@moq/flate/-/flate-0.1.0.tgz",
-      "integrity": "sha512-TJdpmp525u70YHZgBpJ1IS2QXgYAzgZAGm6RIS3bHMMS1dAmWM6Lk6ykX0CgmbzkheDLCUh+fKqD6USSEta/7w==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@moq/flate/-/flate-0.1.1.tgz",
+      "integrity": "sha512-fHuA97OMdvwco/muP01hsg/AxEHzG9Xzr0tuLXI9TXBj7XuZ0uXiIQ4qv26kL6s+emkui/nlieGbr/NvWbPTKQ==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "pako": "^2.2.0"
+        "pako": "^3.0.0"
       }
     },
     "node_modules/@moq/hang": {
@@ -756,13 +755,13 @@
       }
     },
     "node_modules/@moq/json": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@moq/json/-/json-0.1.1.tgz",
-      "integrity": "sha512-It107HOatpHhYO78kHIiu3gZx3icmDt0qyCSkkbbr1wirQIdq0wgQv/FDAsiYI8bYhRRXbPLp43f/VW8yjRHJw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@moq/json/-/json-0.1.2.tgz",
+      "integrity": "sha512-sQz86Iz29lzJIyzY6OtBqJHXxqtcDj2DypPNSEbHSwUQCcOxEzkMS2vhNZEK+oTRN6DpblTmelBeZJPg4RjkjA==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "@moq/flate": "^0.1.0",
-        "@moq/net": "^0.1.6",
+        "@moq/flate": "^0.1.1",
+        "@moq/net": "^0.1.7",
         "@moq/signals": "^0.1.10"
       },
       "peerDependencies": {
@@ -789,12 +788,12 @@
       }
     },
     "node_modules/@moq/net": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@moq/net/-/net-0.1.6.tgz",
-      "integrity": "sha512-hRhR1erz8L9fF+i8Bg6ymg4S/ITa3pjv8/Kq5HAnwR5p6h5PqeQs/6DCS0Zd45ibpRVKv1EliRaFJlOFUV4tFA==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@moq/net/-/net-0.1.8.tgz",
+      "integrity": "sha512-pwx+GcqkH5M/kMk+/0SrXrwNOO8nV0B7bjkHcLD5q35c9FoQfrCwotsjodEEbND6LMDLGJiRUbWNR4gjIZjgyg==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
-        "@moq/qmux": "^0.0.6",
+        "@moq/qmux": "^0.1.3",
         "@moq/signals": "^0.1.10",
         "async-mutex": "^0.5.0"
       },
@@ -815,10 +814,13 @@
       }
     },
     "node_modules/@moq/qmux": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@moq/qmux/-/qmux-0.0.6.tgz",
-      "integrity": "sha512-ISuGz05lUvf1hzHW3Aw3VnsGRJe1w9Qdog3LQ66KS+l+5mzQsPANvW8yOioEe1Z9dJO2G3sAHoGPnzwnsY9SIQ==",
-      "license": "(MIT OR Apache-2.0)"
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@moq/qmux/-/qmux-0.1.3.tgz",
+      "integrity": "sha512-naGmMMOxCSMeLyEATrLiY9RGyeZENC4dHFVVNWNcA17LXE9NwM3aQrQY218xXypWahYIgIkl/ZCutIP2xHibgA==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@moq/web-socket-stream": "^0.1.0"
+      }
     },
     "node_modules/@moq/signals": {
       "version": "0.1.10",
@@ -854,6 +856,12 @@
         "@moq/net": "^0.1.6",
         "@moq/signals": "^0.1.10"
       }
+    },
+    "node_modules/@moq/web-socket-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@moq/web-socket-stream/-/web-socket-stream-0.1.0.tgz",
+      "integrity": "sha512-VxPaJZvZ8qgFmTjG9XhTH0bQoQE9pExvlS/R0fH1aNcpqCnZdbYS2kvB2ypO5SyFTf6oH+4eWvgElDzW6yiqFQ==",
+      "license": "(MIT OR Apache-2.0)"
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
@@ -1103,7 +1111,6 @@
       "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.16.4",
@@ -2787,7 +2794,6 @@
       "resolved": "https://registry.npmjs.org/@pipecat-ai/client-js/-/client-js-1.12.0.tgz",
       "integrity": "sha512-TKHuxTfnO5Eq9VpmSqaPsV0y9lQ+jkb7aEG5MRsmjkhxyhhOW2ljMPwMDzOt+lwS89ZRtk12FUKEaRR/+yBGGg==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@types/events": "^3.0.3",
         "bowser": "^2.11.0",
@@ -3523,7 +3529,6 @@
       "version": "22.16.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3678,7 +3683,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3819,7 +3823,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4097,7 +4100,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4322,7 +4324,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4707,7 +4708,6 @@
       "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -4873,7 +4873,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5589,9 +5588,9 @@
       }
     },
     "node_modules/pako": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
-      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-3.0.1.tgz",
+      "integrity": "sha512-GupotUUI0mlhugKjUs4bjOwLt3nrehy9Ys2dxC0GtgVef5cnKggkDMmf2bq2poCCuVXopWPmqsc9VDT2iJUy+w==",
       "funding": [
         {
           "type": "github",
@@ -5702,7 +5701,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5859,6 +5857,7 @@
       "version": "7.8.2",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -6082,7 +6081,6 @@
     "node_modules/typescript": {
       "version": "5.8.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6164,7 +6162,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6515,7 +6512,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6577,7 +6573,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@moq/hang": "^0.2.12",
-        "@moq/json": "^0.1.1",
+        "@moq/json": "^0.1.2",
         "@moq/net": "^0.1.6",
         "@moq/publish": "^0.2.16",
         "@moq/signals": "^0.1.10",

--- a/transports/moq-transport/package.json
+++ b/transports/moq-transport/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@moq/hang": "^0.2.12",
-    "@moq/json": "^0.1.1",
+    "@moq/json": "^0.1.2",
     "@moq/net": "^0.1.6",
     "@moq/publish": "^0.2.16",
     "@moq/signals": "^0.1.10",

--- a/transports/moq-transport/src/moqTransport.ts
+++ b/transports/moq-transport/src/moqTransport.ts
@@ -22,7 +22,7 @@ import {
 const DEFAULT_NAMESPACE = "pipecat";
 const DEFAULT_CLIENT_ID = "client0";
 const DEFAULT_BOT_ID = "bot0";
-const DEFAULT_TRANSCRIPT_TRACK = "transcript";
+const DEFAULT_TRANSCRIPT_TRACK = "transcript.json.z";
 // Bounded jitter buffer on the audio decoder. Lower = more interactive
 // but more drops on bad networks. Matches the bot's audio_in_max_latency_ms
 // in spirit (each side enforces its own deadline).
@@ -85,10 +85,14 @@ export interface MoqTransportOptions {
   /**
    * Track name for RTVI server→client messages (transcripts, bot-ready,
    * speech events, etc.). The client subscribes at
-   * ``<namespace>/<botId>/<transcriptTrack>``. Defaults to ``"transcript"``.
+   * ``<namespace>/<botId>/<transcriptTrack>``. Defaults to
+   * ``"transcript.json.z"``.
    *
-   * Stays pinned because the transcript is a non-media byte track —
-   * the catalog only describes media tracks (audio/video).
+   * Stays pinned because the transcript is a ``@moq/json`` stream track
+   * (an ordered, lossless append-log, wire-compatible with the bot's Rust
+   * ``moq_json::stream``), not a catalog rendition — the catalog only
+   * describes media tracks (audio/video). The ``.z`` suffix marks that the
+   * stream is compressed.
    */
   transcriptTrack?: string;
 
@@ -175,12 +179,15 @@ function applyDefaults(opts: MoqTransportOptions): ResolvedOptions {
  *   the catalog, ``Watch.Audio.Source`` picks a rendition, and
  *   ``Watch.Audio.Decoder`` + ``Watch.Audio.Emitter`` drive an
  *   ``AudioWorklet`` with a ring buffer (loss-tolerant, low-latency).
- * - ``@moq/json`` for the transcript tracks (snapshot + JSON Merge Patch).
+ * - ``@moq/json`` for the transcript tracks — the ``Stream`` mode: an
+ *   ordered, lossless append-log (wire-compatible with the bot's Rust
+ *   ``moq_json::stream``), so no RTVI event is dropped. Not the snapshot
+ *   mode, which collapses to the latest value.
  * - ``@moq/signals`` for reactive plumbing.
  *
  * Two transcript tracks flow in opposite directions, both named
- * ``transcript`` (or whatever the shared ``transcriptTrack`` option is
- * set to) on their respective broadcasts:
+ * ``transcript.json.z`` (or whatever the shared ``transcriptTrack`` option
+ * is set to) on their respective broadcasts:
  *
  * - Bot → client: bot publishes RTVI events (``bot-output``,
  *   ``bot-transcription``, ``bot-started-speaking``, ``metrics``, …);
@@ -208,10 +215,16 @@ export class MoqTransport extends Transport {
   private _publishBroadcast: Publish.Broadcast | null = null;
   private _microphone: Publish.Source.Microphone | null = null;
   // RTVI JSON side-channel from client → bot, symmetric with the bot's
-  // outbound `transcript` track. Fan-out `Json.Producer` seeded via
-  // `Publish.Broadcast.publishTrack`; `sendMessage` writes to it and the
-  // bot's `_forward_peer_transcript` on the Python side drains it.
-  private _transcriptOut: Json.Producer<RTVIMessage> | null = null;
+  // outbound `transcript` track. Published as a lossless `@moq/json`
+  // append-stream (compression on); `sendMessage` appends each RTVI
+  // message and the bot's `_forward_peer_transcript` on the Python side
+  // drains it. The stream Producer binds to a single track with no
+  // built-in fan-out, and `publishTrack` serves each subscriber its own
+  // track, so we hold one Producer per subscription (`_transcriptOut`)
+  // and replay the message log (`_transcriptLog`) into each — so a bot
+  // that subscribes late still gets every message, in order.
+  private _transcriptOut: Set<Json.Stream.Producer<RTVIMessage>> | null = null;
+  private _transcriptLog: RTVIMessage[] | null = null;
   private _micEnabled = new Signal(true);
   private _micConstraints = new Signal<MediaTrackConstraints | undefined>(
     undefined,
@@ -389,17 +402,28 @@ export class MoqTransport extends Transport {
       },
     });
 
-    // Client-side transcript: `sendMessage` writes each RTVI message
-    // through this fan-out producer, and every bot subscription
-    // (only one, in the normal single-bot flow) sees the stream via
-    // `.serve`. The bot subscribes to this track by its name — same
-    // convention as the bot's own transcript track — so no catalog
-    // entry is needed.
-    this._transcriptOut = new Json.Producer<RTVIMessage>();
+    // Client-side transcript: `sendMessage` appends each RTVI message to
+    // a lossless JSON append-stream. `publishTrack` hands us a fresh track
+    // per subscription (only one, in the normal single-bot flow), so we
+    // spin up a `Json.Stream.Producer` per subscriber and replay the
+    // message log into it — a bot that subscribes after we've already sent
+    // messages still gets the full log, in order. The bot subscribes to
+    // this track by its name — same convention as the bot's own transcript
+    // track — so no catalog entry is needed.
+    this._transcriptLog = [];
+    this._transcriptOut = new Set<Json.Stream.Producer<RTVIMessage>>();
     this._publishBroadcast.publishTrack(
       merged.transcriptTrack,
       (track, effect) => {
-        this._transcriptOut?.serve(track, effect);
+        const producer = new Json.Stream.Producer<RTVIMessage>(track, {
+          compression: true,
+        });
+        for (const msg of this._transcriptLog ?? []) producer.append(msg);
+        this._transcriptOut?.add(producer);
+        effect.cleanup(() => {
+          this._transcriptOut?.delete(producer);
+          producer.finish();
+        });
       },
     );
 
@@ -501,15 +525,17 @@ export class MoqTransport extends Transport {
       );
     });
 
-    // Transcript — snapshot + delta JSON over a single track. We
-    // re-subscribe on each (re)connect; @moq/json.Consumer rebuilds the
-    // value from each group's snapshot frame and yields per-update.
+    // Transcript — a lossless JSON append-stream over a single track. We
+    // re-subscribe on each (re)connect; @moq/json's stream Consumer yields
+    // every appended record in order, losslessly.
     this._signals.run((eff) => {
       const conn = eff.get(this._reload!.established);
       if (!conn) return;
       const botBroadcast = conn.consume(botPath);
       const track = botBroadcast.subscribe(merged.transcriptTrack, 0);
-      const consumer = new Json.Consumer<RTVIMessage>(track);
+      const consumer = new Json.Stream.Consumer<RTVIMessage>(track, {
+        compression: true,
+      });
       const ac = new AbortController();
       this._drainTranscript(consumer, ac.signal).catch((e) => {
         if (!ac.signal.aborted) {
@@ -536,7 +562,10 @@ export class MoqTransport extends Transport {
       this._audioSource?.close();
       this._sync?.close();
       this._watchBroadcast?.close();
-      this._transcriptOut?.finish();
+      if (this._transcriptOut) {
+        for (const producer of this._transcriptOut) producer.finish();
+        this._transcriptOut.clear();
+      }
       this._publishBroadcast?.close();
       this._microphone?.close();
       this._signals?.close();
@@ -548,6 +577,7 @@ export class MoqTransport extends Transport {
       this._sync = null;
       this._watchBroadcast = null;
       this._transcriptOut = null;
+      this._transcriptLog = null;
       this._publishBroadcast = null;
       this._microphone = null;
       this._signals = null;
@@ -645,17 +675,18 @@ export class MoqTransport extends Transport {
   // --------------------------------------------------------------------
 
   sendMessage(message: RTVIMessage): void {
-    if (!this._transcriptOut) {
+    if (!this._transcriptOut || !this._transcriptLog) {
       console.warn(
         "[MoqTransport] sendMessage called before connect; dropping",
         message,
       );
       return;
     }
-    // `Json.Producer.update` writes a snapshot/delta on the transcript
-    // track. RTVI messages carry a unique `id` per message so successive
-    // .update() calls are always seen as changed values, never no-ops.
-    this._transcriptOut.update(message);
+    // Append to the lossless stream. Keep a log too, so a bot that
+    // subscribes after this point is replayed every message in order
+    // (see the `publishTrack` serve callback above).
+    this._transcriptLog.push(message);
+    for (const producer of this._transcriptOut) producer.append(message);
   }
 
   tracks(): Tracks {
@@ -672,11 +703,11 @@ export class MoqTransport extends Transport {
   // Internals — transcript
   // --------------------------------------------------------------------
 
-  /** Pull RTVI messages off the @moq/json consumer and hand each one
-   *  to `PipecatClient` via `_onMessage`. The handler resolves the
+  /** Pull RTVI messages off the @moq/json stream consumer and hand each
+   *  one to `PipecatClient` via `_onMessage`. The handler resolves the
    *  SDK's connect promise when bot-ready arrives. */
   private async _drainTranscript(
-    consumer: Json.Consumer<RTVIMessage>,
+    consumer: Json.Stream.Consumer<RTVIMessage>,
     signal: AbortSignal,
   ): Promise<void> {
     for (;;) {


### PR DESCRIPTION
Stacked on #139 (base `vp-add-moq-transport`). Browser companion to pipecat **pipecat-ai/pipecat#5015**.

## What

Move both MoQ transcript directions from `@moq/json`'s **snapshot** mode
(`Json.Producer`/`Json.Consumer`, RFC 7396 merge-patch) to the **Stream**
mode (`Json.Stream.Producer`/`Json.Stream.Consumer`) — an ordered,
lossless append-log, with **compression on**. Track renamed
`transcript` → `transcript.json.z`.

## Why

Snapshot mode collapses to the latest value: a consumer that has fallen
behind (or joined late) catches up in one step and **silently drops the
intermediate RTVI events**. RTVI is a stream of discrete events
(`bot-output`, `client-ready`, function-call results, …), not a mutating
document, so those drops are lost messages. Stream mode delivers every
appended record, in order.

This is wire-compatible with, and the counterpart to, the bot's Rust
`moq_json::stream` on the Python side (#5015): the bot publishes with
`publish_json_stream(compression=True)` and subscribes to the client's
transcript with `subscribe_json_stream(compression=True)`.

## How

- **Consumer** (bot → client): `new Json.Stream.Consumer(track, { compression: true })`.
- **Producer** (client → bot): the stream `Producer` binds to a single
  track with no built-in fan-out, and `publishTrack` serves each
  subscriber its own track — so we hold one `Producer` per subscription
  and replay a message log into each. A bot that subscribes *after*
  `sendMessage` has already run still gets every message, in order.
- Bump `@moq/json` `^0.1.1` → `^0.1.2` (0.1.2 is the first release
  exposing the `Stream` namespace); re-lock. (The lock also picks up
  transitive updates that `vp-add-moq-transport`'s lock was already behind
  on within its existing ranges.)

## Testing

- `tsc --noEmit`: clean.
- Validated a lossless, compressed round-trip through
  `Json.Stream.Producer` → `Json.Stream.Consumer` (5 RTVI-shaped records
  appended, all 5 back in order).

Note: supersedes #148 (that branch carried this on top of unrelated
@moq/watch audio-playback WIP); this is the standalone JSON-stream change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
