### PR TITLE
Fix bot identification, devicechange listener lifecycle, and ready ga…

### DIFF
--- a/tests/src/transports/livekit.spec.ts
+++ b/tests/src/transports/livekit.spec.ts
@@ -581,6 +581,42 @@ describe("LiveKitTransport — characterization", () => {
       ).toHaveBeenCalledWith(expect.any(Uint8Array), { reliable: true });
     });
 
+    test("sendReadyMessage() ignores track subscriptions from non-bot participants", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+
+      const bot = {
+        identity: "bot-1",
+        name: "Bot",
+        getTrackPublication: () => undefined,
+      };
+      roomOf(transport).remoteParticipants.set("bot-1", bot);
+      roomOf(transport).emit(RoomEvent.ParticipantConnected, bot); // sets _botId
+
+      const readyPromise = transport.sendReadyMessage();
+      await Promise.resolve();
+
+      // Another human's track subscribing doesn't mean the bot can be heard —
+      // "ready" must wait for the bot's own media.
+      roomOf(transport).emit(
+        RoomEvent.TrackSubscribed,
+        { kind: "audio", mediaStreamTrack: {} },
+        { source: Track.Source.Microphone },
+        { identity: "human-2", name: "Other Human" }
+      );
+      await Promise.resolve();
+      expect(transport.state).not.toBe("ready");
+
+      roomOf(transport).emit(
+        RoomEvent.TrackSubscribed,
+        { kind: "audio", mediaStreamTrack: {} },
+        { source: Track.Source.Microphone },
+        bot
+      );
+      await readyPromise;
+      expect(transport.state).toBe("ready");
+    });
+
     test("_disconnect(): disconnecting → disconnected, disconnects room, removes listener, fires onDisconnected", async () => {
       const { callbacks, recorder, spies } = buildSpyCallbacks();
       wireTransport(transport, callbacks);
@@ -680,6 +716,28 @@ describe("LiveKitTransport — characterization", () => {
       expect(transport.isMicEnabled).toBe(false);
       expect(transport.isCamEnabled).toBe(false);
     });
+
+    // initialize() attaches the devicechange listener and _disconnect()
+    // removes it — but client-js only calls transport.initialize() once per
+    // client, so a disconnect → reconnect cycle on the same transport must
+    // re-attach it or device hot-plug handling silently dies for the second
+    // session.
+    test("reconnect after _disconnect() re-attaches the devicechange listener", async () => {
+      const { callbacks } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+      await transport._disconnect();
+
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+
+      const adds = mediaDevices.addEventListener.mock.calls.filter(
+        ([event]) => event === "devicechange"
+      ).length;
+      const removals = mediaDevices.removeEventListener.mock.calls.filter(
+        ([event]) => event === "devicechange"
+      ).length;
+      expect(adds).toBeGreaterThan(removals);
+    });
   });
 
   describe("connection", () => {
@@ -766,6 +824,33 @@ describe("LiveKitTransport — characterization", () => {
         connect(transport, { url: "wss://lk.example", token: "tok" })
       ).rejects.toBeInstanceOf(TransportStartError);
       expect(transport.state).toBe("error");
+    });
+
+    // livekit-client only emits ParticipantConnected for participants who
+    // join *after* us: join-response participants are processed while the
+    // room is still "connecting", and Room.emitWhenConnected() silently drops
+    // (doesn't buffer) events in that state. With the pipecat runner the
+    // agent typically connects before the client does, so already-present is
+    // the common ordering — the transport has to sweep remoteParticipants
+    // itself after connecting.
+    test("_connect() identifies a bot already present in the room at join time", async () => {
+      const { callbacks, spies } = buildSpyCallbacks();
+      wireTransport(transport, callbacks);
+      const bot = {
+        identity: "bot-1",
+        name: "Bot",
+        getTrackPublication: () => undefined,
+      };
+      roomOf(transport).remoteParticipants.set("bot-1", bot);
+
+      await connect(transport, { url: "wss://lk.example", token: "tok" });
+
+      expect(spies.onParticipantJoined).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "bot-1" })
+      );
+      expect(spies.onBotConnected).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "bot-1" })
+      );
     });
   });
 

--- a/transports/livekit-transport/src/liveKitTransport.ts
+++ b/transports/livekit-transport/src/liveKitTransport.ts
@@ -332,6 +332,16 @@ export class LiveKitTransport extends Transport {
 
     this.state = "connecting";
 
+    // Re-attach the devicechange listener dropped by a prior _disconnect() —
+    // initialize() only runs once per client lifetime, so a reconnect on the
+    // same transport must restore it here. Re-adding an already-registered
+    // listener is a no-op per the DOM spec, so the first connect is
+    // unaffected.
+    navigator.mediaDevices.addEventListener(
+      "devicechange",
+      this._deviceChangeHandler
+    );
+
     // Publish alongside connect(), not after it. publishTrack() only waits on
     // the signal (WebSocket) connection, not full ICE/PC negotiation — the
     // AddTrackRequest rides in the same initial offer/answer that's already
@@ -406,6 +416,17 @@ export class LiveKitTransport extends Transport {
 
     this.state = "connected";
     this._callbacks.onConnected?.();
+
+    // livekit-client only emits ParticipantConnected for participants who
+    // join *after* us: join-response participants are processed while the
+    // room is still "connecting", and Room.emitWhenConnected() silently
+    // drops (doesn't buffer) events in that state. The bot usually connects
+    // before the client does, so run whoever's already in the room through
+    // the same handler the event-driven path uses — it sets _botId and fires
+    // onParticipantJoined/onBotConnected.
+    this._room.remoteParticipants.forEach((p) =>
+      this.handleParticipantConnected(p)
+    );
   }
 
   async _disconnect(): Promise<void> {
@@ -886,7 +907,10 @@ export class LiveKitTransport extends Transport {
     logger.debug(
       `[LiveKit Transport] Track subscribed: ${track.kind} ${publication.source} from ${participant.identity}`
     );
-    if (this._readyHandler) {
+    // Only the bot's own media satisfies a pending sendReadyMessage() —
+    // "ready" means we can hear/see the bot, and in a multi-participant room
+    // another human's track subscribing says nothing about that.
+    if (this._readyHandler && participant.identity === this._botId) {
       this._readyHandler();
     }
     const isScreenShare =


### PR DESCRIPTION
…ting

Three review fixes, each with a characterization test added first:

1. Identify a bot already present in the room at join time. livekit-client only emits ParticipantConnected for participants who join after us: join-response participants are processed while the room is still "connecting", and Room.emitWhenConnected() silently drops (doesn't buffer) events in that state. With the pipecat runner the agent typically connects before the client, so _botId was never set -- onBotConnected/onBotDisconnected never fired and tracks().bot was always empty. _connect() now sweeps room.remoteParticipants after connecting, running each through the same handleParticipantConnected path the event-driven flow uses.

2. Re-attach the devicechange listener on reconnect. initialize() attaches it and _disconnect() removes it, but client-js only calls initialize() once per client lifetime -- so a disconnect -> connect cycle on the same transport silently lost device hot-plug handling. _connect() now re-adds the listener (re-adding an identical listener is a no-op per the DOM spec, so the first connect is unaffected).

3. Gate sendReadyMessage() on the bot's own media. handleTrackSubscribed resolved a pending ready promise on any track subscription from any participant; in a multi-participant room another human's track could mark the session ready before the bot published anything. The ready handler now only fires when the subscribed track belongs to _botId (which fix 1 guarantees is set before sendReadyMessage() runs).