### PR TITLE
fix(small-webrtc): stop retrying refused offers and surface the HTTP status

### DIFF
--- a/tests/src/transports/smallWebRtcOfferRefusal.spec.ts
+++ b/tests/src/transports/smallWebRtcOfferRefusal.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * SmallWebRTCTransport offer handling: a 4xx from the offer endpoint must
+ * reject connect() with the status and stop — no blind re-offer, no trickle-ICE
+ * for a peer connection the server never created.
+ */
+
+import { makeRequest } from "@pipecat-ai/client-js";
+import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+  type Mock,
+} from "vitest";
+
+import { createFakeMediaManager } from "../helpers/fakeMediaManager";
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+vi.mock("@pipecat-ai/client-js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@pipecat-ai/client-js")>()),
+  makeRequest: vi.fn(),
+}));
+
+const makeRequestMock = makeRequest as Mock;
+
+class FakePeerConnection {
+  onicecandidate: ((ev: { candidate: unknown }) => void) | null = null;
+  iceGatheringState = "gathering";
+  iceConnectionState = "new";
+  signalingState = "have-local-offer";
+  localDescription: RTCSessionDescriptionInit | null = null;
+  sctp = null;
+
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+  addTransceiver = vi.fn();
+  getTransceivers = vi.fn(() => []);
+  getSenders = vi.fn(() => []);
+  close = vi.fn();
+  createDataChannel = vi.fn(() => ({
+    readyState: "connecting",
+    addEventListener: vi.fn(),
+    close: vi.fn(),
+  }));
+  createOffer = vi.fn(async () => ({ type: "offer", sdp: "v=0" }));
+  setRemoteDescription = vi.fn(async () => {});
+  // Gathering starts as soon as a local description is set — the same moment
+  // the transport POSTs the offer — so a candidate is in flight before the
+  // server has answered.
+  setLocalDescription = vi.fn(async (desc: RTCSessionDescriptionInit) => {
+    this.localDescription = desc;
+    this.onicecandidate?.({
+      candidate: { candidate: "candidate:0", sdpMid: "0", sdpMLineIndex: 0 },
+    });
+  });
+}
+
+const OFFER_ENDPOINT = "https://example.test/webrtc/offer";
+const FLUSH_MS = 200;
+const RETRY_MS = 2000;
+
+describe("SmallWebRTCTransport offer refusal", () => {
+  let transport: SmallWebRTCTransport;
+  let fetchMock: Mock;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("RTCPeerConnection", FakePeerConnection);
+    fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    makeRequestMock.mockReset();
+
+    transport = new SmallWebRTCTransport({
+      mediaManager: createFakeMediaManager() as never,
+      webrtcRequestParams: { endpoint: OFFER_ENDPOINT },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  test("4xx: connect() rejects with the status and the offer is not re-sent", async () => {
+    makeRequestMock.mockRejectedValue(new Response(null, { status: 429 }));
+    const { spies } = buildSpyCallbacks();
+    wireTransport(transport, spies as never);
+
+    const connecting = transport.connect();
+    await expect(connecting).rejects.toMatchObject({ status: 429 });
+    expect(transport.state).toBe("error");
+    expect(spies.onDisconnected).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(RETRY_MS * 3);
+    expect(makeRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("4xx: no trickle-ICE PATCH is sent for the refused offer", async () => {
+    makeRequestMock.mockRejectedValue(new Response(null, { status: 429 }));
+    wireTransport(transport, buildSpyCallbacks().callbacks);
+
+    await transport.connect().catch(() => {});
+    await vi.advanceTimersByTimeAsync(FLUSH_MS * 2);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("5xx: still retries, but ICE candidates wait for an answer", async () => {
+    makeRequestMock.mockRejectedValue(new Response(null, { status: 503 }));
+    wireTransport(transport, buildSpyCallbacks().callbacks);
+
+    void transport.connect().catch(() => {});
+    await vi.advanceTimersByTimeAsync(FLUSH_MS * 2);
+    expect(makeRequestMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(RETRY_MS);
+    expect(makeRequestMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("disconnect() cancels a pending re-offer", async () => {
+    makeRequestMock.mockRejectedValue(new Response(null, { status: 503 }));
+    wireTransport(transport, buildSpyCallbacks().callbacks);
+
+    void transport.connect().catch(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(makeRequestMock).toHaveBeenCalledTimes(1);
+
+    await transport.disconnect();
+    await vi.advanceTimersByTimeAsync(RETRY_MS * 3);
+    expect(makeRequestMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -86,6 +86,13 @@ class SignallingMessageObject {
   }
 }
 
+// A 4xx means the server refused this offer; re-sending it can't succeed.
+const isOfferRefused = (e: unknown): e is Response =>
+  typeof Response !== "undefined" &&
+  e instanceof Response &&
+  e.status >= 400 &&
+  e.status < 500;
+
 const AUDIO_TRANSCEIVER_INDEX = 0;
 const VIDEO_TRANSCEIVER_INDEX = 1;
 const SCREEN_VIDEO_TRANSCEIVER_INDEX = 2;
@@ -566,6 +573,10 @@ export class SmallWebRTCTransport extends Transport {
   private async attemptReconnection(
     recreatePeerConnection: boolean = false
   ): Promise<void> {
+    if (this._abortController?.signal.aborted) {
+      logger.debug("Transport disconnected, skipping reconnection.");
+      return;
+    }
     if (this.isReconnecting) {
       logger.debug("Reconnection already in progress, skipping.");
       return;
@@ -580,15 +591,19 @@ export class SmallWebRTCTransport extends Transport {
     logger.debug(`Reconnection attempt ${this.reconnectionAttempts}...`);
     // aiortc does not seem to work when just trying to restart the ice
     // so for this case we create a new peer connection on both sides
-    if (recreatePeerConnection) {
-      const oldPC = this.pc;
-      await this.startNewPeerConnection(recreatePeerConnection);
-      if (oldPC) {
-        logger.debug("closing old peer connection");
-        this.closePeerConnection(oldPC);
+    try {
+      if (recreatePeerConnection) {
+        const oldPC = this.pc;
+        await this.startNewPeerConnection(recreatePeerConnection);
+        if (oldPC) {
+          logger.debug("closing old peer connection");
+          this.closePeerConnection(oldPC);
+        }
+      } else {
+        await this.negotiate();
       }
-    } else {
-      await this.negotiate();
+    } catch (e) {
+      logger.error(`Reconnection stopped: ${e}`);
     }
   }
 
@@ -692,9 +707,10 @@ export class SmallWebRTCTransport extends Transport {
     }
   }
 
+  /** Resolves true on a successful answer, false when a retry was scheduled. */
   private async negotiate(
     recreatePeerConnection: boolean = false
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!this.pc) {
       return Promise.reject("Peer connection is not initialized");
     }
@@ -775,12 +791,24 @@ export class SmallWebRTCTransport extends Transport {
       // @ts-ignore
       logger.debug(`Received answer for peer connection id ${answer.pc_id}`);
       await this.pc!.setRemoteDescription(answer);
+      return true;
     } catch (e) {
+      if (isOfferRefused(e)) {
+        const error = new RTVIError(
+          `WebRTC offer rejected with status ${e.status}`,
+          e.status
+        );
+        logger.error(error.message);
+        this.state = "error";
+        await this.stop(error);
+        throw error;
+      }
       logger.debug(
         `Reconnection attempt ${this.reconnectionAttempts} failed: ${e}`
       );
       this.isReconnecting = false;
       setTimeout(() => this.attemptReconnection(true), 2000);
+      return false;
     }
   }
 
@@ -822,8 +850,8 @@ export class SmallWebRTCTransport extends Transport {
     this.addInitialTransceivers();
     this.dc = this.createDataChannel("chat", { ordered: true });
     await this.addUserMedia();
-    await this.negotiate(recreatePeerConnection);
-    // Sending the ice candidates
+    const negotiated = await this.negotiate(recreatePeerConnection);
+    if (!negotiated) return;
     this._canSendIceCandidates = true;
     await this.flushIceCandidates();
   }
@@ -950,7 +978,7 @@ export class SmallWebRTCTransport extends Transport {
     pc.close();
   }
 
-  private async stop(): Promise<void> {
+  private async stop(error?: RTVIError): Promise<void> {
     if (!this.pc) {
       logger.debug("Peer connection is already closed or null.");
       return;
@@ -975,7 +1003,7 @@ export class SmallWebRTCTransport extends Transport {
     this._canSendIceCandidates = false;
 
     if (this._connectFailed) {
-      this._connectFailed(new TransportStartError());
+      this._connectFailed(error ?? new TransportStartError());
     }
     this._connectFailed = null;
     this._connectResolved = null;


### PR DESCRIPTION
## Problem

When the offer endpoint returns a 4xx (e.g. 429 quota exceeded, 401/403), `negotiate()` swallows the rejection at debug level and re-sends an identical offer every 2s until `maxReconnectionAttempts`, then rejects `connect()` with a statusless `TransportStartError`.

Meanwhile ICE gathering — started by `setLocalDescription` — trickles candidates via `PATCH` with `pc_id: null` for a peer connection the server never created, producing a stream of 422s alongside the 4xx.

The consumer can't distinguish "server refused" from "network flake" and often stacks its own reconnect loop on top.

## Fix

- 4xx from the offer → reject `connect()` with an `RTVIError` carrying the HTTP status, tear down, no retry. 5xx / network failures keep the existing retry behaviour.
- `_canSendIceCandidates` is only enabled once an answer has been received, so a failed offer (refused or retrying) never PATCHes `pc_id: null`.
- `attemptReconnection()` honours the abort signal so `disconnect()` cancels the 2s/5s timers instead of resurrecting a peer connection after teardown.

## Tests

New `tests/src/transports/smallWebRtcOfferRefusal.spec.ts` (stubbed `RTCPeerConnection` + mocked `makeRequest`), 4 cases:
- 4xx rejects `connect()` with the status and the offer is not re-sent
- 4xx sends no trickle-ICE PATCH
- 5xx still retries, but ICE candidates wait for an answer
- `disconnect()` cancels a pending re-offer

All 4 fail on `main` and pass with this change. Full suite 80/80, prettier clean, `parcel build` OK.

Note: `npm run lint` fails on `main` as well (ESLint 9 with no `eslint.config.*` in the repo) — untouched here.