### PR TITLE
fix(small-webrtc-transport): ignore signalingstatechange events from stale peer connections

### DIFF
--- a/tests/src/helpers/fakeRTCPeerConnection.ts
+++ b/tests/src/helpers/fakeRTCPeerConnection.ts
@@ -26,19 +26,46 @@ export class FakeRTCPeerConnection {
   sctp: { maxMessageSize: number } | null = null;
   onicecandidate: ((event: { candidate: unknown }) => void) | null = null;
 
+  // Real per-instance listener registry (rather than a bare vi.fn() no-op)
+  // so tests can simulate the browser actually firing events — e.g. close()
+  // firing "signalingstatechange" on itself, which is what a stale peer
+  // connection does mid-reconnection.
+  private listeners = new Map<string, Set<() => void>>();
+
   createOffer = vi.fn(async () => ({ type: "offer", sdp: "v=0\r\n" }));
   setLocalDescription = vi.fn(async (desc: RTCSessionDescriptionInit) => {
     this.localDescription = desc;
   });
-  setRemoteDescription = vi.fn(async () => {});
+  setRemoteDescription = vi.fn(async () => {
+    // Real browsers land in "stable" once a valid answer is applied, and
+    // fire signalingstatechange as part of that transition.
+    this.signalingState = "stable";
+    this.dispatch("signalingstatechange");
+  });
   addTransceiver = vi.fn();
-  addEventListener = vi.fn();
-  removeEventListener = vi.fn();
   getTransceivers = vi.fn(() => []);
   getSenders = vi.fn(() => []);
-  close = vi.fn();
-
   createDataChannel = vi.fn(() => new FakeRTCDataChannel());
+
+  addEventListener = vi.fn((type: string, cb: () => void) => {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type)!.add(cb);
+  });
+  removeEventListener = vi.fn((type: string, cb: () => void) => {
+    this.listeners.get(type)?.delete(cb);
+  });
+
+  /** Simulates the browser firing `type` on this connection. */
+  dispatch(type: string) {
+    this.listeners.get(type)?.forEach((cb) => cb());
+  }
+
+  close = vi.fn(() => {
+    // Real browsers transition signalingState to "closed" and fire
+    // signalingstatechange when close() is called.
+    this.signalingState = "closed";
+    this.dispatch("signalingstatechange");
+  });
 }
 
 /**

--- a/tests/src/transports/smallWebRtcReconnection.spec.ts
+++ b/tests/src/transports/smallWebRtcReconnection.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression test for issue #169: the reconnect loop never ended because the
+ * reconnectionAttempts counter was being reset by the old peer connection.
+ *
+ * createPeerConnection() attaches a "signalingstatechange" listener that was
+ * checking `this.pc` (the current, possibly-already-replaced connection)
+ * instead of the closure's own `pc`. During a reconnection retry,
+ * startNewPeerConnection() reassigns `this.pc` to a fresh connection (which
+ * starts "stable") *before* the old connection is closed; closing the old
+ * connection then fires signalingstatechange on itself, and the buggy
+ * handler read `this.pc` (the new, unrelated connection), saw "stable", and
+ * called handleReconnectionCompleted() — zeroing reconnectionAttempts. The
+ * counter oscillated 1/0/1/0 and the transport retried forever instead of
+ * giving up after maxReconnectionAttempts.
+ */
+
+import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  FakeRTCPeerConnection,
+  installFakeRTCPeerConnection,
+} from "../helpers/fakeRTCPeerConnection";
+import { createFakeMediaManager } from "../helpers/fakeMediaManager";
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+const OFFER_ENDPOINT = "https://example.test/offer";
+
+function successfulAnswerResponse(): Response {
+  return new Response(
+    JSON.stringify({ sdp: "v=0\r\n", type: "answer", pc_id: "peer-123" }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+describe("SmallWebRTCTransport reconnection-attempts counter (issue #169)", () => {
+  let mediaManager: ReturnType<typeof createFakeMediaManager>;
+  let transport: SmallWebRTCTransport;
+  let getCurrentPc: () => FakeRTCPeerConnection;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    getCurrentPc = installFakeRTCPeerConnection().current;
+
+    mediaManager = createFakeMediaManager();
+    transport = new SmallWebRTCTransport({
+      mediaManager: mediaManager as never,
+      webrtcRequestParams: { endpoint: OFFER_ENDPOINT },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  test("a stale peer connection's signalingstatechange event does not reset the counter, so the transport gives up after maxReconnectionAttempts", async () => {
+    // Every offer POST fails, forcing attemptReconnection(true) on a 2s
+    // timer. Each retry creates a new RTCPeerConnection and closes the
+    // previous one — exactly the sequence that triggers the stale-event bug.
+    const networkError = new TypeError("network unreachable");
+    const fetchMock = vi.fn(async () => {
+      throw networkError;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    const connectPromise = transport.connect();
+    const caughtPromise = connectPromise.catch(() => {});
+
+    // Advance well past what 1 initial attempt + 3 retries (2s apart) would
+    // need. If the counter were being reset by stale events, the transport
+    // would still be retrying at this point and fetch would keep climbing
+    // past 4 — this is what "retries every 2s indefinitely" looked like.
+    await vi.advanceTimersByTimeAsync(20_000);
+    await caughtPromise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(callbacks.onDisconnected).toHaveBeenCalledTimes(1);
+  });
+
+  test("a legitimate successful reconnect resets the counter, so a later drop gets the full retry budget again", async () => {
+    // First offer POST fails, forcing one reconnection attempt. The retry's
+    // offer succeeds, which should reset reconnectionAttempts back to 0 via
+    // the *current* connection's own signalingstatechange -> "stable" event
+    // (not via a stale one). Every offer POST after that fails again, to
+    // prove the next drop gets a full 3 retries rather than picking up where
+    // the earlier attempt count left off.
+    let callCount = 0;
+    const fetchMock = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 2) return successfulAnswerResponse();
+      throw new TypeError("network unreachable");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    const connectPromise = transport.connect();
+    const caughtPromise = connectPromise.catch(() => {});
+
+    // fetch #1 (initial, fails) -> +2s -> fetch #2 (retry, succeeds).
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Simulate the now-connected peer connection dropping again.
+    const connectedPc = getCurrentPc();
+    connectedPc.iceConnectionState = "failed";
+    connectedPc.dispatch("iceconnectionstatechange");
+
+    // If reconnectionAttempts had NOT been reset by the successful retry,
+    // this second drop would only need 2 more failures (reaching the stale
+    // count of 3) before giving up — 4 fetch calls total. A correctly reset
+    // counter needs the full 3 more retries — 5 fetch calls total.
+    await vi.advanceTimersByTimeAsync(3 * 2000);
+    await caughtPromise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(callbacks.onDisconnected).toHaveBeenCalledTimes(1);
+  });
+});

--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -507,8 +507,9 @@ export class SmallWebRTCTransport extends Transport {
     logger.debug(`iceConnectionState: ${pc.iceConnectionState}`);
 
     pc.addEventListener("signalingstatechange", () => {
-      logger.debug(`signalingState: ${this.pc!.signalingState}`);
-      if (this.pc!.signalingState == "stable") {
+      if (pc !== this.pc) return;
+      logger.debug(`signalingState: ${pc.signalingState}`);
+      if (pc.signalingState == "stable") {
         this.handleReconnectionCompleted();
       }
     });


### PR DESCRIPTION
**NOTE**: I've rebased this on top of #178 to take advantage of the new test infrastructure it introduces. We should merge that one first.

## Summary
- The `signalingstatechange` listener was attached to a specific `pc` instance but checked `this.pc` (the current, possibly-reassigned connection) instead of `pc` itself.
- During reconnection, `startNewPeerConnection()` reassigns `this.pc` to a freshly created connection (which starts in the `"stable"` state) before the old connection is closed. Closing the old connection fires `signalingstatechange` on it, and the handler reads `this.pc` (the new, unrelated connection), sees `"stable"`, and calls `handleReconnectionCompleted()`, resetting `reconnectionAttempts` to 0.
- The counter therefore oscillates between 1 and 0 and never reaches `maxReconnectionAttempts`, so `stop()`/`onDisconnected()` never fire and the mic indicator stays on indefinitely after the network drops.
- Fix: bail out early if the event did not come from the currently active connection (`pc !== this.pc`), and read state off `pc` (the connection that actually fired the event) rather than `this.pc`.

Fixes #169

## Test plan
- [ ] Connect to a bot, wait until audio is flowing, then disable Wi-Fi (DevTools offline mode does not affect WebRTC) and confirm the transport gives up after `maxReconnectionAttempts` and calls `stop()`/`onDisconnected()`
- [ ] Confirm `transport.reconnectionAttempts` increments monotonically during a real outage instead of bouncing between 0 and 1
- [ ] Confirm mic indicator turns off once `stop()` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
