### PR TITLE
fix(small-webrtc-transport): guard keepalive ping against InvalidStateError in Safari

### DIFF
--- a/tests/src/helpers/fakeRTCPeerConnection.ts
+++ b/tests/src/helpers/fakeRTCPeerConnection.ts
@@ -14,8 +14,24 @@ export class FakeRTCDataChannel {
   readyState: string = "connecting";
   send = vi.fn();
   close = vi.fn();
-  addEventListener = vi.fn();
-  removeEventListener = vi.fn();
+
+  // Real per-instance listener registry so tests can simulate the browser
+  // actually firing "open" / "close" — e.g. to drive the keepalive-interval
+  // setup/teardown in createDataChannel().
+  private listeners = new Map<string, Set<(ev?: unknown) => void>>();
+
+  addEventListener = vi.fn((type: string, cb: (ev?: unknown) => void) => {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type)!.add(cb);
+  });
+  removeEventListener = vi.fn((type: string, cb: (ev?: unknown) => void) => {
+    this.listeners.get(type)?.delete(cb);
+  });
+
+  /** Simulates the browser firing `type` on this channel. */
+  dispatch(type: string, ev?: unknown) {
+    this.listeners.get(type)?.forEach((cb) => cb(ev));
+  }
 }
 
 export class FakeRTCPeerConnection {
@@ -45,7 +61,13 @@ export class FakeRTCPeerConnection {
   addTransceiver = vi.fn();
   getTransceivers = vi.fn(() => []);
   getSenders = vi.fn(() => []);
-  createDataChannel = vi.fn(() => new FakeRTCDataChannel());
+
+  /** The most recently created data channel, for tests to reach into. */
+  lastDataChannel: FakeRTCDataChannel | null = null;
+  createDataChannel = vi.fn(() => {
+    this.lastDataChannel = new FakeRTCDataChannel();
+    return this.lastDataChannel;
+  });
 
   addEventListener = vi.fn((type: string, cb: () => void) => {
     if (!this.listeners.has(type)) this.listeners.set(type, new Set());

--- a/tests/src/transports/smallWebRtcKeepAlive.spec.ts
+++ b/tests/src/transports/smallWebRtcKeepAlive.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test for issue #63: SmallWebRTCTransport threw
+ * "InvalidStateError: The object is in an invalid state." in Safari.
+ *
+ * The keepalive interval kept calling dc.send() on a 1s timer with no
+ * readyState check. RTCDataChannel transitions through "open" -> "closing"
+ * -> "closed", but there is no "closing" event — only "close", which is what
+ * actually clears the interval. So there's a window where the channel is
+ * "closing" but the interval hasn't been cleared yet; if a tick lands in
+ * that window, send() is called on a non-open channel. Chrome tolerates
+ * this; Safari throws InvalidStateError.
+ */
+
+import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  FakeRTCPeerConnection,
+  installFakeRTCPeerConnection,
+} from "../helpers/fakeRTCPeerConnection";
+import { createFakeMediaManager } from "../helpers/fakeMediaManager";
+import { buildSpyCallbacks, wireTransport } from "../helpers/observeTransport";
+
+const OFFER_ENDPOINT = "https://example.test/offer";
+
+function successfulAnswerResponse(): Response {
+  return new Response(
+    JSON.stringify({ sdp: "v=0\r\n", type: "answer", pc_id: "peer-123" }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+describe("SmallWebRTCTransport data-channel keepalive (issue #63)", () => {
+  let mediaManager: ReturnType<typeof createFakeMediaManager>;
+  let transport: SmallWebRTCTransport;
+  let getCurrentPc: () => FakeRTCPeerConnection;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    getCurrentPc = installFakeRTCPeerConnection().current;
+
+    mediaManager = createFakeMediaManager();
+    transport = new SmallWebRTCTransport({
+      mediaManager: mediaManager as never,
+      webrtcRequestParams: { endpoint: OFFER_ENDPOINT },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  test("the keepalive ping skips send() while the channel is closing, instead of throwing", async () => {
+    const fetchMock = vi.fn(async () => successfulAnswerResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { callbacks } = buildSpyCallbacks();
+    wireTransport(transport, callbacks);
+
+    const connectPromise = transport.connect();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const dc = getCurrentPc().lastDataChannel!;
+    dc.readyState = "open";
+    dc.dispatch("open");
+    await connectPromise;
+
+    // Discard the syncTrackStatus() sends that happen as part of "open".
+    dc.send.mockClear();
+
+    // While genuinely open, the ping goes out as normal.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(dc.send).toHaveBeenCalledTimes(1);
+
+    // Simulate the channel entering "closing" a tick before "close" actually
+    // fires — the real-world race that produced Safari's InvalidStateError.
+    dc.readyState = "closing";
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(dc.send).toHaveBeenCalledTimes(1); // no additional, unguarded send
+  });
+});

--- a/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
+++ b/transports/small-webrtc-transport/src/smallWebRTCTransport.ts
@@ -973,6 +973,10 @@ export class SmallWebRTCTransport extends Transport {
       }
       // @ts-ignore
       this.keepAliveInterval = setInterval(() => {
+        // This interval can fire while the channel is "closing", before it
+        // gets cleared on "close". Chrome doesn't mind sending a message
+        // then, but Safari will throw an InvalidStateError.
+        if (dc.readyState !== "open") return;
         const message = "ping: " + new Date().getTime();
         dc.send(message);
       }, 1000);


### PR DESCRIPTION
**NOTE: I've rebased this on top of https://github.com/pipecat-ai/pipecat-client-web-transports/pull/177 and #178 to take advantage of the new test infrastructure they introduce. We should merge those first.**

## Summary
- `RTCDataChannel` transitions through `"open" -> "closing" -> "closed"`, but there's no `"closing"` event — only `"close"`, which is what actually clears the keepalive interval (`createDataChannel()`'s `dc.addEventListener("close", ...)` handler).
- If the 1s ping tick lands while the channel is `"closing"` but not yet `"closed"`, `dc.send()` gets called on a non-open channel. Chrome tolerates this; Safari throws `InvalidStateError: The object is in an invalid state.`, matching the report.
- Fix: guard the ping on `dc.readyState === "open"` instead of sending unconditionally. Narrower than the reporter's suggested fix (monkey-patching `dc.send` globally) since every other call site in the file (`sendMessage`, `sendSignallingMessage`, `syncTrackStatus`) already guards `readyState` before calling `dc.send` — only the keepalive interval was missing the check.

Fixes #63

## Test plan
- [x] Added `tests/src/transports/smallWebRtcKeepAlive.spec.ts`: drives a successful connect, opens the fake data channel, confirms the keepalive ping sends while `readyState === "open"`, then flips `readyState` to `"closing"` (simulating the real-world race) and confirms the next tick is skipped rather than calling `send()`.
- [x] Verified the test fails (extra `send()` call) against the pre-fix interval and passes with the fix.
- [x] Full suite passes: 11 files, 83 tests.
- [x] `tsc --noEmit` clean on both `transports/small-webrtc-transport` and `tests` (two pre-existing, unrelated TypedArray errors in `dailyMediaManager.ts`/`mediaManager.ts` aside).

Branch is based on `mb/fix-reconnect-loop-issue-169` (#177), so this PR depends on #177 (and transitively #178) merging first — the diff above is just this fix's incremental change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
