### PR TITLE
chore(gemini-live-websocket-transport, openai-realtime-webrtc-transpo…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6839,7 +6839,7 @@
     },
     "transports/gemini-live-websocket-transport": {
       "name": "@pipecat-ai/gemini-live-websocket-transport",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0"
@@ -6923,7 +6923,7 @@
     },
     "transports/openai-realtime-webrtc-transport": {
       "name": "@pipecat-ai/openai-realtime-webrtc-transport",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@daily-co/daily-js": "^0.90.0",

--- a/transports/gemini-live-websocket-transport/CHANGELOG.md
+++ b/transports/gemini-live-websocket-transport/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to **Pipecat GeminiLiveWebsocketTransport** will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.8](https://github.com/pipecat-ai/pipecat-client-web-transports/compare/gemini-live-websocket-transport-v1.5.7...gemini-live-websocket-transport-v1.5.8) (2026-09-09)
+
+### ⚠ DEPRECATED
+
+**This package is no longer supported and will not receive further updates.** It connects directly from the browser to a third-party LLM API, which we can no longer commit to keeping in sync as that API evolves. See the [repository README](https://github.com/pipecat-ai/pipecat-client-web-transports) for details.
+
+### Bug Fixes
+
+* add a runtime console warning on construction announcing the deprecation
+
 ## [1.5.7](https://github.com/pipecat-ai/pipecat-client-web-transports/compare/gemini-live-websocket-transport-v1.5.6...gemini-live-websocket-transport-v1.5.7) (2026-07-16)
 
 

--- a/transports/gemini-live-websocket-transport/package.json
+++ b/transports/gemini-live-websocket-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipecat-ai/gemini-live-websocket-transport",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "license": "BSD-2-Clause",
   "main": "dist/index.js",
   "module": "dist/index.module.js",

--- a/transports/openai-realtime-webrtc-transport/CHANGELOG.md
+++ b/transports/openai-realtime-webrtc-transport/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to **Pipecat OpenAIRealTimeWebRTCTransport** will be documen
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.8](https://github.com/pipecat-ai/pipecat-client-web-transports/compare/openai-realtime-webrtc-transport-v1.5.7...openai-realtime-webrtc-transport-v1.5.8) (2026-09-09)
+
+### ⚠ DEPRECATED
+
+**This package is no longer supported and will not receive further updates.** It connects directly from the browser to a third-party LLM API, which we can no longer commit to keeping in sync as that API evolves. See the [repository README](https://github.com/pipecat-ai/pipecat-client-web-transports) for details.
+
+### Bug Fixes
+
+* add a runtime console warning on construction announcing the deprecation
+
 ## [1.5.7](https://github.com/pipecat-ai/pipecat-client-web-transports/compare/openai-realtime-webrtc-transport-v1.5.6...openai-realtime-webrtc-transport-v1.5.7) (2026-07-16)
 
 

--- a/transports/openai-realtime-webrtc-transport/package.json
+++ b/transports/openai-realtime-webrtc-transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipecat-ai/openai-realtime-webrtc-transport",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "license": "BSD-2-Clause",
   "main": "dist/index.js",
   "module": "dist/index.module.js",


### PR DESCRIPTION
…rt): Bump versions to 1.5.8 to prep patch release