### PR TITLE
fix(moq-transport): hold client-ready until the bot audio subscription is live

### DIFF
--- a/tests/src/transports/moq.spec.ts
+++ b/tests/src/transports/moq.spec.ts
@@ -131,12 +131,15 @@ describe("MoqTransport — characterization", () => {
     expect(recorder.states).toEqual(["initialized"]);
   });
 
-  test("sendReadyMessage() flips state to 'ready'", () => {
+  test("sendReadyMessage() flips state to 'ready'", async () => {
+    // sendReadyMessage() is async: it first awaits _waitForBotAudio(),
+    // which resolves immediately here because the transport was never
+    // connected (no watch-side signals to wait on).
     const { callbacks, recorder } = buildSpyCallbacks();
     wireTransport(transport, callbacks);
     recorder.states.length = 0;
 
-    transport.sendReadyMessage();
+    await transport.sendReadyMessage();
 
     expect(transport.state).toBe("ready");
     expect(recorder.states).toEqual(["ready"]);

--- a/transports/moq-transport/src/moqTransport.ts
+++ b/transports/moq-transport/src/moqTransport.ts
@@ -688,6 +688,8 @@ export class MoqTransport extends Transport {
   private _waitForBotAudio(timeoutMs = 10_000): Promise<void> {
     const source = this._audioSource;
     const broadcast = this._watchBroadcast;
+    // Both are set in _connect(); if they're null
+    // (bc a `disconnect` happened); resolve immediately;
     if (!source || !broadcast) return Promise.resolve();
     return new Promise((resolve) => {
       let done = false;

--- a/transports/moq-transport/src/moqTransport.ts
+++ b/transports/moq-transport/src/moqTransport.ts
@@ -671,13 +671,52 @@ export class MoqTransport extends Transport {
     }
   }
 
-  sendReadyMessage(): void {
-    // Flip transport state to `ready` and dispatch the RTVI `client-ready`
-    // message on the client→bot transcript track so the bot's RTVIProcessor
-    // can negotiate protocol version. Mirrors the pattern used by
-    // small-webrtc-transport and daily-transport.
+  async sendReadyMessage(): Promise<void> {
+    // `client-ready` is the bot's cue to start speaking, and its audio is
+    // live media with no replay — so hold it until our audio subscription
+    // is on the wire, or the head of the first utterance is lost.
+    await this._waitForBotAudio();
     this.state = "ready";
     this.sendMessage(RTVIMessage.clientReady());
+  }
+
+  /** Resolve once the watch side has issued its audio-track subscribe —
+   *  `Watch.Audio.Decoder` subscribes in an effect gated on exactly these
+   *  three signals. Not gated on received audio: the bot won't speak
+   *  until `client-ready` arrives. The timeout keeps `connect()` from
+   *  hanging against a bot with no audio track. */
+  private _waitForBotAudio(timeoutMs = 10_000): Promise<void> {
+    const source = this._audioSource;
+    const broadcast = this._watchBroadcast;
+    if (!source || !broadcast) return Promise.resolve();
+    return new Promise((resolve) => {
+      let done = false;
+      const eff = new Effect();
+      const finish = () => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        eff.close();
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        console.warn(
+          "[MoqTransport] bot audio not subscribed after " +
+            `${timeoutMs}ms; sending client-ready anyway`
+        );
+        finish();
+      }, timeoutMs);
+      eff.run((e) => {
+        if (
+          e.get(source.track) &&
+          e.get(source.config) &&
+          e.get(broadcast.active)
+        ) {
+          // One macrotask, so the decoder's subscribe effect runs first.
+          setTimeout(finish, 0);
+        }
+      });
+    });
   }
 
   // --------------------------------------------------------------------


### PR DESCRIPTION
TL;DR: this makes `client-ready` event fire at correct time for MoQ transport, so beginning of first message is not cut off.

## What

  Delays sending the RTVI `client-ready` message until the transport's
  subscription to the bot's audio track has been issued.

  `sendReadyMessage()` is now async (the SDK already awaits it): it waits for
  the `@moq/watch` side to reach the state where the audio-track SUBSCRIBE is
  on the wire, then flips to `ready` and sends `client-ready`. A 10s timeout
  falls back to sending immediately with a console warning, so `connect()`
  can't hang against a bot that publishes no audio track.

  ## Why

  `client-ready` is the bot's cue to start speaking, and the bot's audio is
  live media with no replay — anything published before our subscription
  exists is lost.

  Today `client-ready` is sent as soon as `connect()` returns, and because
  the client→bot transcript track replays its log to a late-subscribing bot,
  the message reaches the bot the moment it comes up on a cold start. The
  audio subscription, by contrast, needs several round trips first:
  announcement → catalog subscribe → catalog → rendition selection →
  audio-track SUBSCRIBE. The bot's greeting lands in that gap and the head
  of its first utterance is cut off.

  This was flagged in pipecat-ai/pipecat#5484 (see
  https://github.com/pipecat-ai/pipecat/pull/5484#discussion_r3973148049):
  `on_client_ready` should mean the client is subscribed and ready to
  receive audio, so the fix belongs here rather than only bot-side.

  ## How

  `_waitForBotAudio()` watches `source.track`, `source.config`, and
  `broadcast.active` — exactly the signals that gate `Watch.Audio.Decoder`'s
  internal subscribe effect — and resolves one macrotask after all three are
  set, so the decoder's SUBSCRIBE goes out first. It deliberately does not
  wait for received audio bytes: the bot won't speak until `client-ready`
  arrives, so that would deadlock.

  A small race remains (the SUBSCRIBE propagating relay→bot vs.
  `client-ready` arriving on the transcript track — one relay hop); the
  bot-side `audio_out_subscriber_timeout` from pipecat-ai/pipecat#5484
  still covers that window and non-SDK clients. The two fixes are
  complementary.