### PR TITLE
fix: Fixed issue with mute toggle states being delayed

### DIFF
--- a/lib/media-mgmt/dailyMediaManager.ts
+++ b/lib/media-mgmt/dailyMediaManager.ts
@@ -285,11 +285,20 @@ export class DailyMediaManager extends MediaManager {
     }
   }
 
+  // NOTE: deliberately not `this._daily.localVideo()` / `localAudio()`. Daily
+  // fires 'track-started'/'track-stopped' *before* it commits the new state
+  // to the participant object those getters read from (see daily-js's
+  // DAILY_EVENT_PARTICIPANT_UPDATED handling: maybeEventTrackStopped/Started
+  // run, then `this._participants[id]` is reassigned). Callers that react to
+  // TrackStarted/TrackStopped by reading isCamEnabled/isMicEnabled — e.g. to
+  // resync UI state — would otherwise always observe the pre-toggle value.
+  // _camEnabled/_micEnabled are updated synchronously in
+  // handleTrackStarted/handleTrackStopped below, before those callbacks fire.
   get isCamEnabled(): boolean {
-    return this._daily.localVideo();
+    return this._camEnabled;
   }
   get isMicEnabled(): boolean {
-    return this._daily.localAudio();
+    return this._micEnabled;
   }
   get isSharingScreen(): boolean {
     return this._daily.localScreenAudio() || this._daily.localScreenVideo();
@@ -401,7 +410,22 @@ export class DailyMediaManager extends MediaManager {
         }
       }
     };
-    this._callbacks.onDeviceError?.(generateDeviceError(ev.error));
+    const deviceError = generateDeviceError(ev.error);
+    // enableMic()/enableCam() set _micEnabled/_camEnabled optimistically,
+    // but setLocalAudio()/setLocalVideo() are fire-and-forget — no promise,
+    // no synchronous failure signal — so a failed request (blocked
+    // permission, device in use, etc.) leaves that optimistic value wrong
+    // with nothing to correct it: no track-started/stopped ever fires for
+    // an operation that didn't actually take effect. This is the only
+    // signal we get that the request failed, so resync from Daily's actual
+    // state for whichever device(s) it implicates.
+    if (deviceError.devices.includes("mic")) {
+      this._micEnabled = this._daily.localAudio();
+    }
+    if (deviceError.devices.includes("cam")) {
+      this._camEnabled = this._daily.localVideo();
+    }
+    this._callbacks.onDeviceError?.(deviceError);
   }
 
   private _handleLocalAudioLevel(ev: DailyEventObjectLocalAudioLevel) {
@@ -415,6 +439,7 @@ export class DailyMediaManager extends MediaManager {
   protected async handleTrackStarted(event: DailyEventObjectTrack) {
     if (!event.participant?.local) return;
     if (event.track.kind === "audio") {
+      this._micEnabled = true;
       if (this._mediaStreamRecorder) {
         const status = this._mediaStreamRecorder.getStatus();
         switch (status) {
@@ -454,6 +479,8 @@ export class DailyMediaManager extends MediaManager {
         }
       }
       this._currentAudioTrack = event.track;
+    } else if (event.track.kind === "video") {
+      this._camEnabled = true;
     }
     this._callbacks.onTrackStarted?.(
       event.track,
@@ -467,12 +494,15 @@ export class DailyMediaManager extends MediaManager {
   protected handleTrackStopped(event: DailyEventObjectTrack) {
     if (!event.participant?.local) return;
     if (event.track.kind === "audio") {
+      this._micEnabled = false;
       if (
         this._mediaStreamRecorder &&
         this._mediaStreamRecorder.getStatus() === "recording"
       ) {
         this._mediaStreamRecorder.pause();
       }
+    } else if (event.track.kind === "video") {
+      this._camEnabled = false;
     }
     this._callbacks.onTrackStopped?.(
       event.track,

--- a/transports/daily/src/transport.ts
+++ b/transports/daily/src/transport.ts
@@ -130,6 +130,20 @@ export class DailyTransport extends Transport {
   private _audioQueue: ArrayBuffer[] = [];
   declare private _mediaStreamRecorder: MediaStreamRecorder;
 
+  // NOTE: deliberately not read live off `this._daily.localAudio()` /
+  // `localVideo()` in the isMicEnabled/isCamEnabled getters below. Daily
+  // fires 'track-started'/'track-stopped' *before* it commits the new state
+  // to the participant object those calls read from (daily-js emits the
+  // track event from within its participant-updated handling, then
+  // reassigns its internal participant cache afterwards). Code that reacts
+  // to TrackStarted/TrackStopped by reading isMicEnabled/isCamEnabled to
+  // resync UI state — e.g. PipecatClientState's mic/cam sync — would
+  // otherwise always observe the pre-toggle value. These fields are updated
+  // synchronously in enableMic/enableCam and in handleTrackStarted/
+  // handleTrackStopped, before those callbacks fire.
+  private _micEnabled: boolean = true;
+  private _camEnabled: boolean = false;
+
   constructor(opts: DailyTransportConstructorOptions = {}) {
     super();
 
@@ -236,6 +250,8 @@ export class DailyTransport extends Transport {
       // Default is mic on
       this._dailyFactoryOptions.startAudioOff = !(options.enableMic ?? true);
     }
+    this._camEnabled = !this._dailyFactoryOptions.startVideoOff;
+    this._micEnabled = !this._dailyFactoryOptions.startAudioOff;
 
     this.attachEventListeners();
 
@@ -330,24 +346,26 @@ export class DailyTransport extends Transport {
     // joined — pre-session, daily-js can't act on the request because the
     // call object isn't part of a meeting yet.
     this._dailyFactoryOptions.startAudioOff = !enable;
+    this._micEnabled = enable;
     if (this._daily.participants()?.local) {
       this._daily.setLocalAudio(enable);
     }
   }
 
   get isMicEnabled() {
-    return this._daily.localAudio();
+    return this._micEnabled;
   }
 
   enableCam(enable: boolean) {
     this._dailyFactoryOptions.startVideoOff = !enable;
+    this._camEnabled = enable;
     if (this._daily.participants()?.local) {
       this._daily.setLocalVideo(enable);
     }
   }
 
   get isCamEnabled() {
-    return this._daily.localVideo();
+    return this._camEnabled;
   }
 
   public enableScreenShare(enable: boolean) {
@@ -719,7 +737,22 @@ export class DailyTransport extends Transport {
         }
       }
     };
-    this._callbacks.onDeviceError?.(generateDeviceError(ev.error));
+    const deviceError = generateDeviceError(ev.error);
+    // enableMic()/enableCam() set _micEnabled/_camEnabled optimistically,
+    // but setLocalAudio()/setLocalVideo() are fire-and-forget — no promise,
+    // no synchronous failure signal — so a failed request (blocked
+    // permission, device in use, etc.) leaves that optimistic value wrong
+    // with nothing to correct it: no track-started/stopped ever fires for
+    // an operation that didn't actually take effect. This is the only
+    // signal we get that the request failed, so resync from Daily's actual
+    // state for whichever device(s) it implicates.
+    if (deviceError.devices.includes("mic")) {
+      this._micEnabled = this._daily.localAudio();
+    }
+    if (deviceError.devices.includes("cam")) {
+      this._camEnabled = this._daily.localVideo();
+    }
+    this._callbacks.onDeviceError?.(deviceError);
   }
 
   private async handleLocalAudioTrack(track: MediaStreamTrack) {
@@ -768,8 +801,13 @@ export class DailyTransport extends Transport {
           : undefined
       );
     } else {
-      if (ev.participant?.local && ev.track.kind === "audio") {
-        void this.handleLocalAudioTrack(ev.track);
+      if (ev.participant?.local) {
+        if (ev.track.kind === "audio") {
+          this._micEnabled = true;
+          void this.handleLocalAudioTrack(ev.track);
+        } else if (ev.track.kind === "video") {
+          this._camEnabled = true;
+        }
       }
       this._callbacks.onTrackStarted?.(
         ev.track,
@@ -789,6 +827,13 @@ export class DailyTransport extends Transport {
           : undefined
       );
     } else {
+      if (ev.participant?.local) {
+        if (ev.track.kind === "audio") {
+          this._micEnabled = false;
+        } else if (ev.track.kind === "video") {
+          this._camEnabled = false;
+        }
+      }
       this._callbacks.onTrackStopped?.(
         ev.track,
         ev.participant


### PR DESCRIPTION
Fixed an issue in the Daily Transport and MediaManager where the mic/camEnabled flag was stale in the track-started/stopped events. Previously, the flag was based on daily's localVideo()/Audio(), but those have not yet updated at the moment track-started/stopped are called, so if you rely on those in your handler, the state is wrong.